### PR TITLE
Add support for artwork credits in card footer

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -40,11 +40,9 @@ const {
   stage,
   artwork,
   background,
-  footer,
-  footertext,
-  footertextRight,
   flatFooterText,
   dentedFooterText,
+  artworkCreditsText,
   loadingBackground,
   containerElement,
   contentElement,
@@ -334,6 +332,16 @@ const [lifeImage] = useImage('/img/symbols/cardsymbol_life.svg');
                   </div>
                 </div>
               </div>
+              <div v-if="fields.cardType !== ''" class="">
+                <label class="block text-sm/6 font-medium text-primary dark:text-white" for="cardLife">Artwork credits</label>
+                <div class="mt-2">
+                  <div class="flex items-center rounded-md bg-white dark:bg-dark pl-3 outline-1 -outline-offset-1 outline-gray-300 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-primary">
+                    <input id="cardLife" v-model="fields.cardArtworkCredits"
+                           class="block min-w-0 grow py-1.5 pr-3 pl-1 text-base text-primary dark:text-white placeholder:text-gray-400 focus:outline-none sm:text-sm/6"
+                           type="text">
+                  </div>
+                </div>
+              </div>
               <div v-show="isFieldShown('cardText')" class="sm:col-span-2">
                 <label v-if="['hero', 'demi_hero'].includes(fields.cardType)" id="cardHeroPowerLabel" class="block text-sm/6 font-medium text-primary dark:text-white" for="cardText">Hero power</label>
                 <label v-else id="cardTextLabel" class="block text-sm/6 font-medium text-primary dark:text-white" for="cardText">Card text</label>
@@ -466,27 +474,62 @@ const [lifeImage] = useImage('/img/symbols/cardsymbol_life.svg');
                         v-bind="{...getConfig('cardTypeText'), fontSize: typeTextFontSize}"
                     ></v-text>
                   </v-layer>
-                  <v-layer id="footer" ref="footer">
+                  <v-layer id="footer">
                     <v-image v-if="fields.cardRarity" id="cardRarity" :image="cardRarityImage" v-bind="getConfig('cardRarity')"></v-image>
-                    <v-text
-                        ref="footertext"
-                        :fontSize="footerTextFontSize"
-                        :text="dentedFooterText"
-                        v-bind="getConfig('cardFooterText')"
-                    />
-                    <v-text
-                        v-if="selectedStyle === 'flat'"
-                        ref="footertextRight"
-                        :fontSize="footerTextFontSize"
-                        :text="flatFooterText"
-                        v-bind="getConfig('cardFooterTextRight')"
-                    />
-
-                    <!-- Copyright overlay -->
-                    <v-text
-                        text="©"
-                        v-bind="getConfig('copyrightOverlay')"
-                    />
+                    <template v-if="selectedStyle === 'dented'">
+                      <v-text
+                          :fontSize="footerTextFontSize"
+                          :text="artworkCreditsText"
+                          v-bind="getConfig('cardArtworkCredits')"
+                      />
+                      <v-text
+                          v-if="fields.cardArtworkCredits !== ''"
+                          :fontSize="footerTextFontSize"
+                          :text="dentedFooterText"
+                          v-bind="getConfig('cardFooterText')"
+                      />
+                      <v-text
+                          v-if="fields.cardArtworkCredits !== ''"
+                          text="©"
+                          v-bind="{...getConfig('copyrightOverlayBottom')}"
+                      />
+                      <v-text
+                          v-else
+                          text="©"
+                          v-bind="{...getConfig('copyrightOverlay')}"
+                      />
+                    </template>
+                    <template v-if="selectedStyle === 'flat'">
+                      <template v-if="fields.cardArtworkCredits !== ''">
+                        <v-text
+                            :fontSize="footerTextFontSize"
+                            :text="artworkCreditsText"
+                            v-bind="getConfig('cardFooterText')"
+                        />
+                        <v-text
+                            :fontSize="footerTextFontSize"
+                            text="NOT TOURNAMENT LEGAL"
+                            v-bind="getConfig('cardFooterTextBottom')"
+                        />
+                      </template>
+                      <template v-else>
+                        <v-text
+                            :fontSize="footerTextFontSize"
+                            text="FABKIT  |  NOT TOURNAMENT LEGAL"
+                            v-bind="getConfig('cardFooterText')"
+                        />
+                      </template>
+                      <v-text
+                          :fontSize="footerTextFontSize"
+                          :text="flatFooterText"
+                          v-bind="getConfig('cardFooterTextRight')"
+                      />
+                      <!-- Copyright overlay -->
+                      <v-text
+                          text="©"
+                          v-bind="getConfig('copyrightOverlay')"
+                      />
+                    </template>
                   </v-layer>
                 </v-stage>
               </div>

--- a/src/config/cardSettings.js
+++ b/src/config/cardSettings.js
@@ -93,6 +93,17 @@ const cardSettings = {
             },
             cardFooterText: {
                 x: 128,
+                y: 607.9,
+                width: 204,
+                height: 12,
+                fontFamily: 'dialog_cond_semiboldregular, Arial, sans-serif',
+                fontSize: 10.43,
+                verticalAlign: "top",
+                fill: "white",
+                align: "left",
+            },
+            cardArtworkCredits: {
+                x: 128,
                 y: 595.9,
                 width: 204,
                 height: 12,
@@ -105,6 +116,17 @@ const cardSettings = {
             copyrightOverlay: {
                 x: 305,  // Position where © appears in the dented footer
                 y: 595.5,
+                width: 10,
+                height: 12,
+                fontFamily: 'Arial',
+                fontSize: 10.43,
+                verticalAlign: "top",
+                fill: "white",
+                align: "center",
+            },
+            copyrightOverlayBottom: {
+                x: 272,  // Position where © appears in the dented footer
+                y: 607.5,
                 width: 10,
                 height: 12,
                 fontFamily: 'Arial',
@@ -350,6 +372,17 @@ const cardSettings = {
                 x: 30,
                 y: 76,
             },
+            cardArtworkCredits: {
+                x: 128,
+                y: 595.9,
+                width: 204,
+                height: 12,
+                fontFamily: 'dialog_cond_semiboldregular, Arial, sans-serif',
+                fontSize: 10.43,
+                verticalAlign: "top",
+                fill: "white",
+                align: "left",
+            },
             cardFooterText: {
                 x: 46.4,  // Adjust for left alignment
                 y: 598.4,
@@ -358,8 +391,19 @@ const cardSettings = {
                 fontFamily: 'dialog_cond_semiboldregular, "Arial Narrow", "Helvetica Condensed", Arial, sans-serif',
                 fontSize: 10,
                 verticalAlign: "top",
-                fill: "white",  // Changed to black for flat
+                fill: "white",
                 align: "left",
+            },
+            cardFooterTextBottom: {
+                x: 0,  // Adjust for left alignment
+                y: 610.4,
+                width: 450,
+                height: 12,
+                fontFamily: 'dialog_cond_semiboldregular, "Arial Narrow", "Helvetica Condensed", Arial, sans-serif',
+                fontSize: 10,
+                verticalAlign: "top",
+                fill: "white",
+                align: "center",
             },
             cardFooterTextRight: {
                 x: 222.5,  // Adjust for right side positioning

--- a/src/helpers/canvas.js
+++ b/src/helpers/canvas.js
@@ -4,7 +4,6 @@ const CanvasHelpers = class CanvasHelper {
     background = '';
     artworkLayer;
     backgroundLayer;
-    footerLayer;
 
     constructor() {
     }

--- a/src/helpers/card.js
+++ b/src/helpers/card.js
@@ -34,6 +34,7 @@ export function useCard() {
         cardLife: '',
         cardUploadedArtwork: '',
         cardFooterText: '',
+        cardArtworkCredits: '',
     });
     const cardTypeText = computed(() => {
         const classText = fields.cardClass;
@@ -400,11 +401,22 @@ export function useCard() {
         if (!fontsLoaded.value) {
             return '';
         }
-        if (selectedStyle.value === 'flat') {
-            return 'FABKIT  |  NOT TOURNAMENT LEGAL';
-        }
-        return `FABKIT - NOT TOURNAMENT LEGAL - FaB TCG BY${String.fromCharCode(0x00A0)}${String.fromCharCode(0x00A0)}${String.fromCharCode(0x00A0)}LSS`;
+        return `NOT TOURNAMENT LEGAL - FaB TCG BY${String.fromCharCode(0x00A0)}${String.fromCharCode(0x00A0)}${String.fromCharCode(0x00A0)}LSS`;
     });
+
+    const artworkCreditsText = computed(() => {
+        if (!fontsLoaded.value) {
+            return '';
+        }
+        if (selectedStyle.value === 'flat') {
+            if (!fields.cardArtworkCredits) return '';
+            return 'FABKIT  | ' + fields.cardArtworkCredits;
+        }
+
+        if (!fields.cardArtworkCredits) return 'FABKIT - ' + dentedFooterText.value;
+
+        return `FABKIT - ` + fields.cardArtworkCredits;
+    })
 
     const resizeText = ({element, minSize = frameTypeTextConfig.value.minFontSize, maxSize = frameTypeTextConfig.value.maxFontSize, step = frameTypeTextConfig.value.step, unit = 'px'}) => {
         if (!element) {
@@ -516,9 +528,6 @@ export function useCard() {
     const stage = ref();
     const artwork = ref();
     const background = ref();
-    const footer = ref();
-    const footertext = ref();
-    const footertextRight = ref();
 
     const canvasHelper = new CanvasHelper();
 
@@ -593,7 +602,6 @@ export function useCard() {
         fields.cardRarity = 1;
         canvasHelper.artworkLayer = artwork.value.getStage();
         canvasHelper.backgroundLayer = background.value.getStage();
-        canvasHelper.footerLayer = footer.value.getStage();
         updateSize();
         recalculateRatio();
         // Add event listener
@@ -731,11 +739,9 @@ export function useCard() {
         stage,
         artwork,
         background,
-        footer,
-        footertext,
-        footertextRight,
         flatFooterText,
         dentedFooterText,
+        artworkCreditsText,
         containerElement,
         contentElement,
         stageContainerRef,


### PR DESCRIPTION
Introduced a new "artwork credits" field that allows specifying custom credits in card footers. Updated the logic to display these credits dynamically based on the card style (flat or dented). Adjusted related configurations and cleaned up unused footer references.