### PR TITLE
Community standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,vue,css,scss,sass,less,styl}]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+end_of_line = lf
+max_line_length = 100

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,103 @@
+# Set default behavior to automatically normalize line endings
+* text=auto eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout
+*.js text eol=lf
+*.ts text eol=lf
+*.vue text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
+*.editorconfig text eol=lf
+
+# Package files
+package.json text eol=lf
+package-lock.json text eol=lf -diff
+yarn.lock text eol=lf -diff
+pnpm-lock.yaml text eol=lf -diff
+
+# Configuration files
+*.config.js text eol=lf
+*.config.mjs text eol=lf
+*.config.ts text eol=lf
+*.config.json text eol=lf
+vite.config.* text eol=lf
+.env* text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.woff2 binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary
+*.jar binary
+*.class binary
+*.so binary
+*.dll binary
+*.exe binary
+
+# Fonts
+*.otf binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.woff2 binary
+
+# Images
+*.ai binary
+*.bmp binary
+*.eps binary
+*.gif binary
+*.gifv binary
+*.ico binary
+*.jng binary
+*.jp2 binary
+*.jpg binary
+*.jpeg binary
+*.jpx binary
+*.jxr binary
+*.pdf binary
+*.png binary
+*.psb binary
+*.psd binary
+*.svg text
+*.svgz binary
+*.tif binary
+*.tiff binary
+*.wbmp binary
+*.webp binary
+
+# Linguist overrides for generated files
+dist/* linguist-generated=true
+build/* linguist-generated=true
+coverage/* linguist-generated=true
+*.min.js linguist-generated=true
+*.min.css linguist-generated=true
+/src/config/cardbacks.js linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Defines owners of specific parts of the codebase.
+
+# As recommended by Github, owner of this file (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection)
+.github/CODEOWNERS    @lambstream
+
+# Style and visual related changes
+/src/styles/**/*      @LouisVanKey
+/src/assets/**/*      @LouisVanKey
+/public/**/*          @LouisVanKey
+
+# Code / Functionality related ownership
+*.js                  @lambstream
+*.vue                 @lambstream

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: fabkit

--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -1,0 +1,125 @@
+name: "🐛 Bug report"
+description: Report something that isn't working as it should or is outright broken
+title: "[BUG]: "
+labels: ["bug"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              **Before You Start...**
+
+              This form is only for submitting bug reports. If you have a usage question
+              or are unsure if this is really a bug, make sure to:
+
+              - Read the [documentation](https://github.com/FABKIT/FABKIT/blob/master/README.md)
+              - Check [existing issues](https://github.com/FABKIT/FABKIT/issues) for similar problems
+              - Ask on [GitHub Discussions](https://github.com/FABKIT/FABKIT/discussions)
+
+              Also try to search for your issue - it may have already been answered or even fixed in the development branch.
+              However, if you find that an old, closed issue still persists in the latest version,
+              you should open a new issue using the form below instead of commenting on the old issue.
+
+    - type: dropdown
+      id: operating-system
+      attributes:
+          label: Operating System
+          description: Which operating system are you using?
+          options:
+              - Windows (Computer / Laptop)
+              - Linux (specify distro below)
+              - macOS (MacBook / Mac)
+              - Android (specify version below)
+              - iOS
+              - Other
+      validations:
+          required: true
+
+    - type: textarea
+      id: operating-system-extra
+      attributes:
+          label: Provide additional information
+          description: Most operating systems request additional information like the version
+      validations:
+          required: false
+
+    - type: textarea
+      id: steps-to-reproduce
+      attributes:
+          label: Steps to reproduce
+          description: |
+              Please provide clear, step-by-step instructions to reproduce the bug.
+              Include specific actions like "Select Card type", "Select Type", etc.
+          placeholder: |
+              1. Open FABKIT
+              2. Select Card Type
+              3. Click on...
+              4. See error
+      validations:
+          required: true
+
+    - type: textarea
+      id: expected-behaviour
+      attributes:
+          label: Expected behaviour
+          description: |
+              What did you expect to happen? Describe the intended behaviour clearly.
+      validations:
+          required: true
+
+    - type: textarea
+      id: actual-behaviour
+      attributes:
+          label: Actual behaviour
+          description: |
+              What actually happened? Describe what went wrong, including any error messages,
+              crashes, or unexpected behaviour.
+              Most browsers allow you to open developer information using `F12`, include contents of the `console` tab
+      validations:
+          required: true
+
+    - type: textarea
+      id: card-details
+      attributes:
+          label: Card details
+          description: |
+              If this bug occurs with a card setup, please provide details:
+              - Card Type
+              - Pitch
+              - Name
+              - Image
+          placeholder: |
+              - Action card
+              - Old style
+              - Custom image (uploaded by dragging here)
+              - Special description
+
+    - type: textarea
+      id: additional-context
+      attributes:
+          label: Additional context
+          description: |
+              Add any other context about the problem here. This might include:
+              - Screenshots or recordings (drag and drop files here)
+              - Workarounds you've discovered
+              - Similar issues in other applications
+              - When the problem started occurring
+          placeholder: Any additional information that might help us understand and fix the issue...
+
+    - type: markdown
+      attributes:
+          value: |
+              ---
+
+              **Important Notes:**
+
+              - **Complete information required**: Issues that are incomplete or missing required information will be automatically closed. Please fill out all required fields thoroughly.
+
+              - **Additional information**: Maintainers may request additional information, logs, or steps to reproduce the issue. Please respond promptly to help us resolve your issue quickly.
+
+              - **Attachments**: You can drag and drop files (screenshots, crash reports, log files, project files) directly into any text area above.
+
+              - **Response time**: We'll do our best to respond quickly, but please be patient as this is a volunteer-maintained project.
+
+              - **Duplicates**: Before submitting, please search existing issues to avoid duplicates. We may close duplicate reports in favour of the original issue.
+
+              Thank you for helping improve FABKIT! 🗺️

--- a/.github/ISSUE_TEMPLATE/01-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/01-feature-request.yml
@@ -1,0 +1,133 @@
+name: "✨ Feature request"
+description: Suggest a new feature or enhancement for FABKIT
+title: "[FEATURE]: "
+labels: ["enhancement"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              **Before You Start...**
+
+              This form is for requesting new features or enhancements to FABKIT. Please:
+
+              - Check [existing issues](https://github.com/FABKIT/FABKIT/issues) to avoid duplicates
+              - Search [GitHub Discussions](https://github.com/FABKIT/FABKIT/discussions) for similar requests
+              - Consider if this is truly a new feature or if it's a bug in existing functionality
+
+              **Note:** Feature requests are evaluated based on community interest, alignment with project goals, and development resources.
+
+    - type: dropdown
+      id: feature-category
+      attributes:
+          label: Feature Category
+          description: What area of FABKIT would this feature affect?
+          options:
+              - "Card Types"
+              - "Additional text options"
+              - "Artwork customization"
+              - "Export / Save related"
+              - "Missing options"
+              - "Performance (speed, memory)"
+              - "Other (specify in description)"
+      validations:
+          required: true
+
+    - type: textarea
+      id: feature-summary
+      attributes:
+          label: Feature Summary
+          description: |
+              Provide a clear, concise summary of the feature you're requesting.
+              What should FABKIT be able to do that it currently can't?
+          placeholder: "e.g., Add support for even more awesome cards!"
+      validations:
+          required: true
+
+    - type: textarea
+      id: use-case
+      attributes:
+          label: Use Case & Problem
+          description: |
+              Describe the specific problem or need this feature would address.
+              What workflow or task would this improve?
+          placeholder: |
+              This would help me because...
+              Without this feature, I have to work around it by...
+      validations:
+          required: true
+
+    - type: textarea
+      id: proposed-solution
+      attributes:
+          label: Proposed Solution
+          description: |
+              Describe your ideal solution. How would you like this feature to work?
+              Be as specific as possible about the user experience.
+          placeholder: |
+              The interface could have...
+              When I do X, it should...
+      validations:
+          required: true
+
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Alternative Solutions
+          description: |
+              Have you considered other ways to solve this problem?
+              Are there alternative approaches or workarounds?
+          placeholder: |
+              Other editors handle this by...
+              An alternative approach could be...
+              Currently I work around this by...
+
+    - type: textarea
+      id: examples
+      attributes:
+          label: Examples or References
+          description: |
+              If this feature exists elsewhere, please provide examples, screenshots, or links.
+              You can drag and drop images or files here.
+          placeholder: |
+              Similar to this feature in Photoshop...
+              Example image: [drag and drop here]
+
+    - type: textarea
+      id: implementation-thoughts
+      attributes:
+          label: Implementation Thoughts
+          description: |
+              If you have technical knowledge, do you have thoughts on how this might be implemented?
+              (This is optional and intended for developers or technically-minded users)
+          placeholder: |
+              This might require changes to...
+              Could potentially use the existing... system
+              Might be challenging because...
+
+    - type: textarea
+      id: additional-context
+      attributes:
+          label: Additional Context
+          description: |
+              Any other information, screenshots, mockups, or context that would help us understand your request.
+              You can drag and drop files here.
+          placeholder: |
+              Mockup image showing the proposed UI...
+              Link to community discussion about this...
+              Related to issue #123...
+
+    - type: markdown
+      attributes:
+          value: |
+              ---
+
+              **What Happens Next?**
+
+              1. **Community Discussion**: Feature requests are often discussed in the community before implementation
+              2. **Evaluation**: We'll evaluate the request based on project goals, technical feasibility, and resources
+              3. **Roadmap**: Accepted features will be added to our roadmap and assigned to future milestones
+              4. **Updates**: We'll keep you informed of the status and any decisions made
+
+              **Note:** Not all feature requests can be implemented immediately. We prioritise based on community needs, project direction, and available development time.
+
+              Thank you for helping make FABKIT better! 🗺️

--- a/.github/ISSUE_TEMPLATE/99-internal.yml
+++ b/.github/ISSUE_TEMPLATE/99-internal.yml
@@ -1,0 +1,21 @@
+name: "🔧 Technical/Internal"
+description: "[CONTRIBUTORS ONLY] Technical discussion, refactoring, or internal work"
+labels: ["internal"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              **⚠️ This template is intended for project contributors and maintainers only.**
+
+              If you're not a contributor, please use the appropriate template:
+              - [Bug Report](https://github.com/FABKIT/FABKIT/issues/new?assignees=&labels=bug&template=00-bug-report.yml) for issues
+              - [Feature Request](https://github.com/FABKIT/FABKIT/issues/new?assignees=&labels=enhancement&template=01-feature-request.yml) for enhancements
+              - [Discussions](https://github.com/FABKIT/FABKIT/discussions) for questions
+
+              Tickets created using this template by non-maintainers will be closed without exception.
+
+    - type: textarea
+      id: body
+      attributes:
+          label: Required work
+          description: What needs to be worked on.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Questions & Discussions
+      url: https://github.com/FABKIT/FABKIT/discussions
+      about: Use GitHub discussions for message-board style questions, discussions and feature requests
+
+    - name: Support development
+      url: https://ko-fi.com/fabkit
+      about: If you want to support the development, check out our Ko-Fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+    # Group all patch updates together
+    groups:
+      production-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@types/*"
+          - "stylelint*"
+          - "vite*"
+          - "@vitejs/*"
+        update-types:
+          - "patch"
+          - "minor"
+      development-dependencies:
+        patterns:
+          - "@types/*"
+          - "stylelint*"
+          - "vite*"
+          - "@vitejs/*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "github-actions"
+      - "ci"

--- a/.github/workflows/internal-issue-guard.yaml
+++ b/.github/workflows/internal-issue-guard.yaml
@@ -1,0 +1,55 @@
+name: Internal Issue Guard
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-technical-issues:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: contains(github.event.issue.labels.*.name, 'internal')
+    steps:
+      - name: Check if user has write permission
+        id: check-permission
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.issue.user.login
+              });
+
+              const hasWriteAccess = ['write', 'admin'].includes(permission.permission);
+              core.setOutput('has-access', hasWriteAccess);
+
+            } catch (error) {
+              // If user is not a collaborator, the API returns 404
+              if (error.status === 404) {
+                core.setOutput('has-access', false);
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Close Issue
+        if: steps.check-permission.outputs.has-access == 'false'
+        uses: peter-evans/close-issue@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment: |
+            Thanks for your interest in FABKIT!
+
+            The **Technical/Internal** template is reserved for project maintainers and contributors with write access.
+
+            For your issue, please use one of these templates instead:
+            - 🐛 [**Bug Report**](https://github.com/FABKIT/FABKIT/issues/new?template=bug-report.yml) - if something isn't working correctly
+            - ✨ [**Feature Request**](https://github.com/FABKIT/FABKIT/issues/new?template=feature-request.yml) - if you'd like to suggest an enhancement
+            - 💬 [**Discussions**](https://github.com/FABKIT/FABKIT/discussions) - for questions or general discussion
+
+            This helps us keep technical issues organised and ensures your feedback gets the attention it deserves in the right place.

--- a/.github/workflows/new-contributors.yaml
+++ b/.github/workflows/new-contributors.yaml
@@ -1,0 +1,32 @@
+name: Welcome new contributors
+on:
+  pull_request:
+    types: [ opened, closed ]
+  issues:
+    types: [ opened ]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  greet-if-new:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ ! contains(github.event.issue.labels.*.name, 'internal') }}
+    steps:
+      - uses: wow-actions/welcome@v1
+        with:
+          FIRST_ISSUE: |
+            👋 @{{ author }}, this is the first time you're opening an issue.
+            Take a moment to read the [contribution guidelines](https://github.com/FABKIT/FABKIT/blob/master/CONTRIBUTING).
+
+          FIRST_PR: |
+            👋 @{{ author }}
+            Thanks for opening this pull request! Please check out our [contribution guidelines](https://github.com/FABKIT/FABKIT/blob/master/CONTRIBUTING).
+
+          FIRST_PR_MERGED: |
+            🎉 @{{ author }}
+            Congrats on merging your first pull request, we appreciate your contribution!
+
+          FIRST_PR_MERGED_REACTIONS: hooray

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,197 @@
+# AI Development Guidelines for FABKIT
+
+This document provides guidelines for AI agents working on the FABKIT project to ensure consistent, high-quality contributions while maintaining project standards and conventions.
+
+## Project Overview
+
+FABKIT is a Vue.js-based canvas/design tool built with:
+- **Frontend**: Vue 3 + TypeScript + Vite
+- **Styling**: Tailwind CSS + SCSS
+- **Canvas**: Konva.js + Vue-Konva
+- **Rich Text**: TipTap editor
+- **UI Components**: Headless UI + Heroicons
+
+## Code Standards
+
+### File Structure and Naming
+- Use kebab-case for file names: `my-component.vue`, `utility-functions.ts`
+- Vue components should be PascalCase in imports: `MyComponent`
+- Follow Vue 3 Composition API patterns with `<script setup>`
+
+### Code Style
+- Use TypeScript for all new JavaScript code
+- Follow Vue 3 style guide and best practices
+- Use Tailwind CSS classes for styling
+- Custom styles should be written in SCSS
+- Run `npm run lint` before committing (stylelint for SCSS)
+
+### Vue Component Guidelines
+```vue
+<script setup lang="ts">
+// Imports first
+import { ref, computed } from 'vue'
+import MyComponent from './MyComponent.vue'
+
+// Props definition
+interface Props {
+  title: string
+  isVisible?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  isVisible: true
+})
+
+// Emits definition
+const emit = defineEmits<{
+  close: []
+  update: [value: string]
+}>()
+
+// Reactive state
+const isOpen = ref(false)
+
+// Computed properties
+const displayTitle = computed(() => props.title.toUpperCase())
+
+// Methods
+const handleClick = () => {
+  emit('close')
+}
+</script>
+
+<template>
+  <div class="component-container">
+    <!-- Use semantic HTML -->
+    <!-- Apply Tailwind classes consistently -->
+  </div>
+</template>
+
+<style lang="scss" scoped>
+// Component-specific styles only when Tailwind is insufficient
+.component-container {
+  // Use SCSS features when needed
+}
+</style>
+```
+
+## Key Dependencies and Usage
+
+### Canvas Operations (Konva.js)
+- Use `vue-konva` components: `v-stage`, `v-layer`, `v-rect`, etc.
+- Handle canvas events through Vue event handlers
+- Maintain canvas state in Vue reactive references
+
+### Rich Text Editor (TipTap)
+- Configured extensions: Bold, Italic, Strike, Underline, Lists, Text Align
+- Use TipTap's Vue 3 integration for editor instances
+- Follow TipTap patterns for custom extensions
+
+### UI Components
+- Prefer Headless UI components for accessibility
+- Use Heroicons for consistent iconography
+- Implement responsive design with Tailwind breakpoints
+
+## Development Workflow
+
+### Before Making Changes
+1. Understand the existing code structure and patterns
+2. Check for similar implementations in the codebase
+3. Ensure changes align with Vue 3 and TypeScript best practices
+4. Consider performance implications for canvas operations
+
+### Testing and Quality
+- Test canvas interactions thoroughly
+- Verify responsive behavior across device sizes
+- Ensure accessibility standards are maintained
+- Run linting: `npm run lint`
+- Test build process: `npm run build`
+
+### File Organization
+```
+src/
+├── components/        # Reusable Vue components
+├── views/            # Page-level components
+├── composables/      # Vue composition functions
+├── utils/           # Utility functions
+├── types/           # TypeScript type definitions
+├── styles/          # Global SCSS styles
+└── assets/          # Static assets
+```
+
+## Common Patterns
+
+### State Management
+- Use Vue 3 Composition API with `ref()` and `reactive()`
+- Create composables for shared logic
+- Avoid global state unless necessary
+
+### Canvas State
+- Keep canvas objects in reactive references
+- Use Vue's reactivity for canvas updates
+- Implement proper cleanup in `onUnmounted()`
+
+### Component Communication
+- Use props for parent-to-child data flow
+- Use emits for child-to-parent communication
+- Consider provide/inject for deep component trees
+
+## Styling Guidelines
+
+### Tailwind CSS
+- Use utility classes for layout, spacing, and basic styling
+- Prefer responsive utilities: `md:text-lg`, `lg:grid-cols-3`
+- Use consistent color palette from Tailwind config
+
+### SCSS
+- Use SCSS only when Tailwind is insufficient
+- Follow BEM methodology for custom CSS classes
+- Scope styles properly with `scoped` attribute
+
+## Performance Considerations
+
+### Canvas Performance
+- Minimize canvas redraws
+- Use object pooling for frequently created/destroyed objects
+- Implement efficient event handling for large numbers of objects
+
+### Vue Performance
+- Use `v-memo` for expensive list rendering
+- Implement proper key attributes for `v-for`
+- Consider `shallowRef()` for large objects that don't need deep reactivity
+
+## Security Guidelines
+
+- Sanitize user inputs, especially in rich text editor
+- Validate file uploads and canvas data
+- Follow secure coding practices for any server interactions
+
+## AI Agent Specific Notes
+
+### Code Generation
+- Always check existing patterns before creating new ones
+- Maintain consistency with current TypeScript interfaces
+- Use proper Vue 3 Composition API patterns
+- Include appropriate type annotations
+
+### File Modifications
+- Read existing files to understand current patterns
+- Preserve existing code style and formatting
+- Add comments only when complex logic requires explanation
+- Update related files when making architectural changes
+
+### Testing Changes
+- Test canvas functionality after modifications
+- Verify responsive design works correctly
+- Ensure no TypeScript compilation errors
+- Run linting to catch style issues
+
+## Questions and Clarifications
+
+When uncertain about implementation details:
+1. Check similar components in the codebase
+2. Refer to Vue 3, TipTap, or Konva documentation
+3. Ask for clarification on project-specific patterns
+4. Propose solutions with alternatives when unsure
+
+Remember: Consistency with existing patterns is more important than perfect adherence to external standards.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+Discord (see README).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+## Quick Start
+
+[fabkit.github.io/FABKIT](https://fabkit.io/)
+
+### Local Development
+
+```bash
+# Clone the repository
+git clone https://github.com/FABKIT/FABKIT.git
+cd FABKIT
+
+# Install dependencies
+npm install
+
+# Set up environment variables
+cp .env.example .env
+# Edit .env with your backend URL if needed
+
+# Start development server
+npm run dev
+
+# Build for production
+npm run build
+```
+
+### Ways to Contribute
+- [Report bugs](https://github.com/FABKIT/FABKIT/issues)
+- [Suggest features](https://github.com/FABKIT/FABKIT/issues)
+- Submit pull requests
+- Improve documentation
+- Share card designs and feedback
+
+### Development Setup
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/amazing-feature`
+3. Make your changes and test thoroughly
+4. Commit with clear messages: `git commit -m 'Add amazing feature'`
+5. Push to your fork: `git push origin feature/amazing-feature`
+6. Open a Pull Request
+
+## Tech Stack
+
+- **Frontend**: Vue 3 with Composition API
+- **Styling**: Tailwind CSS v4
+- **Canvas Rendering**: Konva.js for high-quality card generation
+- **Text Editor**: Tiptap with custom FAB symbol integration
+- **Build Tool**: Vite
+- **Deployment**: GitHub Pages

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-BSD 3-Clause License
+# BSD 3-Clause License
 
-Copyright (c) 2025, FABKIT
+Copyright (c) 2025, **FABKIT**
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FABKIT
 
-> **Your Flesh and Blood Toolbox** 
+> **Your Flesh and Blood Toolbox**
 
-[![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
+[![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE.md)
 [![Built with Vue](https://img.shields.io/badge/Built%20with-Vue%203-4FC08D.svg)](https://vuejs.org/)
 [![Live Demo](https://img.shields.io/badge/Live%20Demo-fabkit.github.io-brightgreen.svg)](https://fabkit.io/)
 
@@ -73,7 +73,7 @@ npm run build
 ### FAB Symbol Integration
 Use our symbol buttons in the text editor to add official FAB symbols:
 - Resource symbols
-- Power symbols  
+- Power symbols
 - Defense symbols
 - Life symbols
 - Intellect symbols
@@ -118,7 +118,7 @@ Your support helps us dedicate more time to bringing new features to life and ke
 
 ## License
 
-This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE.md) file for details.
 
 ## Legal
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+> [!WARNING]
+> **Please do not report security vulnerabilities through public GitHub issues.**
+
+If you discover a security vulnerability in FABKIT, please report it privately through GitHub Security Advisories:
+
+1. Go to the [Security tab](https://github.com/FABKIT/FABKIT/security) of this repository
+2. Click "Report a vulnerability"
+3. Fill out the advisory form with details
+
+## What to Include
+
+When reporting a vulnerability, please include:
+
+- **Description** of the vulnerability
+- **Steps to reproduce** the issue
+- **Potential impact** and attack scenarios
+- **Suggested fixes** (if you have any)
+- **Your contact information** for follow-up questions
+
+## Response Process
+
+1. **Acknowledgement**: We'll acknowledge receipt of your report within 48 hours
+2. **Investigation**: We'll investigate and assess the vulnerability
+3. **Timeline**: We'll provide an estimated timeline for a fix
+4. **Updates**: We'll keep you informed of our progress
+5. **Resolution**: We'll notify you when the vulnerability is resolved
+6. **Disclosure**: We'll coordinate responsible disclosure timing with you


### PR DESCRIPTION
This PR adds (most) of the files recommended by Github community standards (see #30).
The effect of most files on the Github interface can be viewed [here](https://github.com/dealloc/FABKIT/tree/chore/community-standards) while the PR is open.

Highlights:
- adds shortcuts to code of conduct, contribution, license and security
<img width="797" height="99" alt="image" src="https://github.com/user-attachments/assets/8ba256a2-6f1b-4b69-b41c-4741704806d7" />

- Outlines a security policy which links to Github's security advisory (this also improves how the security tab itself looks)
<img width="938" height="381" alt="image" src="https://github.com/user-attachments/assets/a039aeb0-93c8-4b1e-b62d-6855a68e09a4" />

- extracts the contribution guidelines to it's own `CONTRIBUTING.md`

- Adds "sponsor" button linked to Ko-Fi
<img width="324" height="94" alt="image" src="https://github.com/user-attachments/assets/587f51c1-2523-43b1-b495-1efa66fc26c1" />

- Adds 3 issue templates:
  - bug report
  - feature request
  - internal (including workflow to prevent non-maintainers from opening internal tickets)
- CODEOWNERS which will automatically add maintainers as reviewer to PR if a file under their "ownership"

What may need extra attention:
The github issue templates are based on those in [dungeon-rs](https://github.com/dungeon-rs/dungeon-rs/issues) and [helldivers-2/api](https://github.com/helldivers-2/api/issues) (see screenshots of respective setup below):
<img width="816" height="451" alt="image" src="https://github.com/user-attachments/assets/b3402e19-25af-4506-9873-0d914f88bc90" />

The questions may need adjusting based on maintainer needs.