### PR TITLE
Split bundles

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,14 +3,12 @@ import './styles/index.scss'
 import {createRouter, createWebHashHistory} from "vue-router";
 import Home from "./components/Home.vue";
 import App from "./App.vue";
-import Roadmap from "./components/Roadmap.vue";
 import Contact from "./components/Contact.vue";
 import VueKonva from 'vue-konva';
-import WorkInProgress from "./components/WorkInProgress.vue";
 
 const routes = [
     {path: '/', name:'home', component: Home},
-    {path: '/roadmap', name: 'roadmap', component: Roadmap},
+    {path: '/roadmap', name: 'roadmap', component: () => import('./components/Roadmap.vue') },
     {path: '/contact', name: 'contact', component: Contact},
 ]
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,6 +22,7 @@ export default defineConfig(async ({mode}) => {
             port: 8080,
         },
         build: {
+          cssCodeSplit: true,
           rollupOptions: {
             output: {
               manualChunks: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,5 +21,17 @@ export default defineConfig(async ({mode}) => {
             // host: '0.0.0.0',
             port: 8080,
         },
+        build: {
+          rollupOptions: {
+            output: {
+              manualChunks: {
+                lottie: ['lottie-web'],
+                tiptap: ['@tiptap/core', 'prosemirror-transform', 'prosemirror-model', 'prosemirror-view'],
+                emoji: ['@tiptap/extension-emoji'],
+                konva: ['konva'],
+              }
+            }
+          }
+        }
     }
 })


### PR DESCRIPTION
Currently on `master` running `npm run build` generates the following output:
<img width="1069" height="358" alt="image" src="https://github.com/user-attachments/assets/65342969-98b4-4f5f-bfa0-94fa884977c9" />

The main bundle size is currently ~1.8MB (gzipped still half a megabyte).
A bundle breakdown of this yields:
<img width="1712" height="1275" alt="image" src="https://github.com/user-attachments/assets/5b823173-cc73-4e5e-947b-940df78f992f" />

Majority of the bundle size is taken up by `lottie-web` and `extension-emoji` (from tiptap).
this PR forces a chunk split for lottie, tiptap (with separate emojis) and konva.
A bundle breakdown of this PR yields:
<img width="724" height="282" alt="image" src="https://github.com/user-attachments/assets/f2a15c7f-408e-460a-8aae-e2c7198a26ed" />
<img width="1717" height="1279" alt="image" src="https://github.com/user-attachments/assets/ae7c47c0-b158-485a-aa16-69af325b4c52" />

Now the largest bundle is the emojis (which I couldn't shrink further) with a gzip transfer of 61kb.
since the generated `index.html` file generates following entries:
```html
      <script type="module" crossorigin src="/assets/index-CwZPOlJF.js"></script>
      <link rel="modulepreload" crossorigin href="/assets/lottie-BINtRlk9.js">
      <link rel="modulepreload" crossorigin href="/assets/konva-Bo21XYCp.js">
      <link rel="modulepreload" crossorigin href="/assets/tiptap-DRvwWKof.js">
      <link rel="modulepreload" crossorigin href="/assets/emoji-BvQz9emV.js">
      <link rel="stylesheet" crossorigin href="/assets/index-CQaCr3Nm.css">
```
this will cause the browser to load these bundles (which are ~100kb each) in parallel rather than one big bundle of 1.8MB and should improve loading times significantly.

Besides chunk splitting, this PR also makes the `Roadmap.vue` component lazy loaded since *most* people will just use the "main" page and thus the average user will load less data (again, faster page loads!) at the cost of a *small* increase in page loading times when opening roadmap (the first time)