### PR TITLE
feat(card-creator): add line break button, artwork clip, new talents …

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -30,6 +30,8 @@
 			"lightning": "Lightning",
 			"mystic": "Mystic",
 			"pirate": "Pirate",
+			"revered": "Revered",
+			"reviled": "Reviled",
 			"royal": "Royal",
 			"shadow": "Shadow"
 		},
@@ -64,6 +66,7 @@
 			"invocation": "Invocation",
 			"item": "Item",
 			"shuriken_item": "Shuriken Item",
+			"cog_item": "Cog Item",
 			"landmark": "Landmark",
 			"song": "Song",
 			"trap": "Trap",

--- a/src/components/card-creator/Renderer/NormalRenderer.tsx
+++ b/src/components/card-creator/Renderer/NormalRenderer.tsx
@@ -154,10 +154,16 @@ export function NormalRenderer({ config, ref }: NormalRendererProps) {
 		>
 			<title>{CardName}</title>
 			<defs>
-				{/* TODO: re-add mask when rendering issues have been fixed. */}
-				{/*<mask id="artwork-mask" mask-type="luminance">*/}
-				{/*	{config.masks.CardArtWork}*/}
-				{/*</mask>*/}
+				{config.artworkClip && (
+					<clipPath id="artwork-clip">
+						<rect
+							x={config.artworkClip.x}
+							y={config.artworkClip.y}
+							width={config.artworkClip.width}
+							height={config.artworkClip.height}
+						/>
+					</clipPath>
+				)}
 				<clipPath id="title-clip">{config.clips.Title}</clipPath>
 				<clipPath id="bottom-text-clip">{config.clips.BottomText}</clipPath>
 			</defs>
@@ -170,7 +176,7 @@ export function NormalRenderer({ config, ref }: NormalRendererProps) {
 					width={CardArtPosition?.width || 0}
 					height={CardArtPosition?.height || 0}
 					preserveAspectRatio="xMidYMid slice"
-					mask="url(#artwork-mask)"
+					clipPath={config.artworkClip ? "url(#artwork-clip)" : undefined}
 				/>
 			)}
 

--- a/src/components/form/RichTextEditor.tsx
+++ b/src/components/form/RichTextEditor.tsx
@@ -15,6 +15,7 @@ import {
 	AlignLeft as AlignLeftIcon,
 	Bold as BoldIcon,
 	Italic as ItalicIcon,
+	CornerDownLeft as LineBreakIcon,
 	List as ListBulletIcon,
 	ListOrdered as NumberedListIcon,
 	Underline as UnderlineIcon,
@@ -194,6 +195,19 @@ export default function RichTextEditor({
 					>
 						<span className="sr-only">Center</span>
 						<AlignCenterIcon aria-hidden="true" className="size-4" />
+					</button>
+				</div>
+
+				{/* Line Break */}
+				<div className="inline-flex rounded-lg bg-surface-muted p-1">
+					<button
+						type="button"
+						onClick={() => editor.chain().focus().setHardBreak().run()}
+						className="relative inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition-all duration-150 focus:z-10 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 text-body hover:bg-primary/10"
+						title="Insert line break (move to next line)"
+					>
+						<span className="sr-only">Insert line break</span>
+						<LineBreakIcon aria-hidden="true" className="size-4" />
 					</button>
 				</div>
 

--- a/src/config/cards/subtypes.ts
+++ b/src/config/cards/subtypes.ts
@@ -13,6 +13,7 @@ export const CardSubtypes: Record<CardType, Record<string, string>> = {
 		invocation: "card.subtype.invocation",
 		item: "card.subtype.item",
 		shuriken_item: "card.subtype.shuriken_item",
+		cog_item: "card.subtype.cog_item",
 		landmark: "card.subtype.landmark",
 		song: "card.subtype.song",
 	},

--- a/src/config/cards/talents.ts
+++ b/src/config/cards/talents.ts
@@ -9,6 +9,8 @@ export const CardTalents = {
 	lightning: "card.talent.lightning",
 	mystic: "card.talent.mystic",
 	pirate: "card.talent.pirate",
+	revered: "card.talent.revered",
+	reviled: "card.talent.reviled",
 	royal: "card.talent.royal",
 	shadow: "card.talent.shadow",
 } as const;

--- a/src/config/rendering/preset.tsx
+++ b/src/config/rendering/preset.tsx
@@ -34,6 +34,10 @@ export const NormalDentedRenderConfigPreset: NormalDentedRenderConfig = {
 	},
 	// Stops just before CardText.y (400) — the lowest text-box top across all dented variants
 	artworkDragZone: { x: 10, y: 10, width: 430, height: 385 },
+	// Clip the artwork so it stays inside the card frame.
+	// x/y = top-left corner of the visible area, width/height = size of the visible area.
+	// Increase x or decrease width to pull in the right/left edges; adjust y/height for top/bottom.
+	artworkClip: { x: 10, y: 10, width: 430, height: 608 },
 	masks: {
 		CardArtWork: <rect x="10" y="10" width="430" height="608" fill="white" />,
 	},
@@ -282,6 +286,10 @@ export const NormalFlatRenderConfigPreset: NormalFlatRenderConfig = {
 	},
 	// Stops just before CardText.y (~392) — the lowest text-box top across all flat variants
 	artworkDragZone: { x: 10, y: 10, width: 430, height: 380 },
+	// Clip the artwork so it stays inside the card frame.
+	// x/y = top-left corner of the visible area, width/height = size of the visible area.
+	// Increase x or decrease width to pull in the right/left edges; adjust y/height for top/bottom.
+	artworkClip: { x: 10, y: 10, width: 430, height: 608 },
 	masks: {
 		CardArtWork: <rect x="10" y="10" width="430" height="608" fill="white" />,
 	},

--- a/src/config/rendering/types.ts
+++ b/src/config/rendering/types.ts
@@ -207,6 +207,21 @@ export interface BaseCardRenderConfig {
 	masks: Record<string, ReactElement>;
 
 	/**
+	 * Rectangular clip region for the card artwork.
+	 * Anything drawn outside this box will be hidden — use it to stop the
+	 * artwork from bleeding past the card frame.
+	 *
+	 * Tweak these four numbers in preset.tsx per card style:
+	 * - x      → left edge of the visible area (higher = narrower on the left)
+	 * - y      → top edge of the visible area  (higher = narrower on the top)
+	 * - width  → how wide the visible area is  (lower = narrows the right edge)
+	 * - height → how tall the visible area is  (lower = narrows the bottom edge)
+	 *
+	 * All values are in the SVG coordinate system (card viewBox is 450×628).
+	 */
+	artworkClip?: { x: number; y: number; width: number; height: number };
+
+	/**
 	 * SVG clipPath definitions for constraining text overflow.
 	 * Used to ensure text doesn't exceed designated areas.
 	 * Applied via clipPath="url(#clip-id)" attribute.


### PR DESCRIPTION
- Add a line break toolbar button to the card text editor so users can manually push a word to the next line
   - Add a configurable artwork clip to normal card presets to prevent artwork from bleeding outside the card frame
   - Add Revered and Reviled to the talent list
   - Add Cog Item to the action card subtype list

   - Add a line break toolbar button to the card text editor so users can manually push a word to the next line
   - Add a configurable artwork clip to normal card presets to prevent artwork from bleeding outside the card frame
   - Add Revered and Reviled to the talent list
   - Add Cog Item to the action card subtype list

   ## Changes

   - `RichTextEditor.tsx` — new hard break button (↵ icon) in the toolbar
   - `NormalRenderer.tsx` — artwork now uses a `clipPath` to stay within card bounds
   - `preset.tsx` / `types.ts` — new `artworkClip` config field, adjustable per card style
   - `talents.ts` + `subtypes.ts` — Revered, Reviled, Cog Item added
   - `en.json` — translations added for all new entries