### PR TITLE
perf: replace @tiptap/extension-emoji with a minimal local extension

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@tanstack/react-router-devtools": "^1.166.13",
         "@tiptap/extension-bold": "^3.22.5",
         "@tiptap/extension-document": "^3.22.5",
-        "@tiptap/extension-emoji": "^3.22.5",
         "@tiptap/extension-italic": "^3.22.5",
         "@tiptap/extension-list": "^3.22.5",
         "@tiptap/extension-paragraph": "^3.22.5",
@@ -497,8 +496,6 @@
 
     "@tiptap/extension-dropcursor": ["@tiptap/extension-dropcursor@3.22.5", "", { "peerDependencies": { "@tiptap/extensions": "3.22.5" } }, "sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA=="],
 
-    "@tiptap/extension-emoji": ["@tiptap/extension-emoji@3.22.5", "", { "dependencies": { "emoji-regex": "^10.6.0", "emojibase-data": "^17", "is-emoji-supported": "^0.0.5" }, "peerDependencies": { "@tiptap/core": "3.22.5", "@tiptap/pm": "3.22.5", "@tiptap/suggestion": "3.22.5" } }, "sha512-nSjSsDNY0NxWc15Vr9V2cB5aVHQSZrs3aho58FlHJMvx03et4vfO4TtQP9lSRUL3le09SOTR56EcR/M91k4BGQ=="],
-
     "@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@3.22.5", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "3.22.5", "@tiptap/pm": "3.22.5" } }, "sha512-dhem4sTPhyQgQ+pFp2Oud4k4FSQz9PVMgeQAC9288SmGwxBkJNveDAw6sKTMrumqDvwkJrtslXIupq9TZYQnzg=="],
 
     "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.22.5", "", { "peerDependencies": { "@tiptap/extensions": "3.22.5" } }, "sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg=="],
@@ -538,8 +535,6 @@
     "@tiptap/react": ["@tiptap/react@3.22.5", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.22.5", "@tiptap/extension-floating-menu": "^3.22.5" }, "peerDependencies": { "@tiptap/core": "3.22.5", "@tiptap/pm": "3.22.5", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-36WHEs+vPmB//V1ff7Ujcnpz7Ey5g8lhpI/0+hoanSbdiPMTQ7qZVWwMovIkMKDlqWVp2fxBgeYM1861jyFzTw=="],
 
     "@tiptap/starter-kit": ["@tiptap/starter-kit@3.22.5", "", { "dependencies": { "@tiptap/core": "^3.22.5", "@tiptap/extension-blockquote": "^3.22.5", "@tiptap/extension-bold": "^3.22.5", "@tiptap/extension-bullet-list": "^3.22.5", "@tiptap/extension-code": "^3.22.5", "@tiptap/extension-code-block": "^3.22.5", "@tiptap/extension-document": "^3.22.5", "@tiptap/extension-dropcursor": "^3.22.5", "@tiptap/extension-gapcursor": "^3.22.5", "@tiptap/extension-hard-break": "^3.22.5", "@tiptap/extension-heading": "^3.22.5", "@tiptap/extension-horizontal-rule": "^3.22.5", "@tiptap/extension-italic": "^3.22.5", "@tiptap/extension-link": "^3.22.5", "@tiptap/extension-list": "^3.22.5", "@tiptap/extension-list-item": "^3.22.5", "@tiptap/extension-list-keymap": "^3.22.5", "@tiptap/extension-ordered-list": "^3.22.5", "@tiptap/extension-paragraph": "^3.22.5", "@tiptap/extension-strike": "^3.22.5", "@tiptap/extension-text": "^3.22.5", "@tiptap/extension-underline": "^3.22.5", "@tiptap/extensions": "^3.22.5", "@tiptap/pm": "^3.22.5" } }, "sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw=="],
-
-    "@tiptap/suggestion": ["@tiptap/suggestion@3.17.1", "", { "peerDependencies": { "@tiptap/core": "^3.17.1", "@tiptap/pm": "^3.17.1" } }, "sha512-a188uVYjlLsUiwK3Ki7KsaWVWC0u28KsqGEAqCk9ECYmtVY99Hrb+rcAwGpMjA7tn8WAwThOxiLISoMdpuqXwg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -695,10 +690,6 @@
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "emojibase": ["emojibase@17.0.0", "", {}, "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA=="],
-
-    "emojibase-data": ["emojibase-data@17.0.0", "", { "peerDependencies": { "emojibase": "*" } }, "sha512-Yvgb5AWoHViHV/gq1qr5ZAarcBip+B27/ZLRsUJkbgAEaLlZ/fof9g882LTpmEpyhBNEC0m2SEmItljHsTygjA=="],
-
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
@@ -824,8 +815,6 @@
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
-    "is-emoji-supported": ["is-emoji-supported@0.0.5", "", {}, "sha512-WOlXUhDDHxYqcSmFZis+xWhhqXiK2SU0iYiqmth5Ip0FHLZQAt9rKL5ahnilE8/86WH8tZ3bmNNNC+bTzamqlw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"@tanstack/react-router-devtools": "^1.166.13",
 		"@tiptap/extension-bold": "^3.22.5",
 		"@tiptap/extension-document": "^3.22.5",
-		"@tiptap/extension-emoji": "^3.22.5",
 		"@tiptap/extension-italic": "^3.22.5",
 		"@tiptap/extension-list": "^3.22.5",
 		"@tiptap/extension-paragraph": "^3.22.5",

--- a/src/platform/components/form/RichTextEditor.tsx
+++ b/src/platform/components/form/RichTextEditor.tsx
@@ -1,5 +1,4 @@
 import Bold from "@tiptap/extension-bold";
-import Emoji from "@tiptap/extension-emoji";
 import { BulletList, ListItem, OrderedList } from "@tiptap/extension-list";
 import TextAlign from "@tiptap/extension-text-align";
 import Underline from "@tiptap/extension-underline";
@@ -21,16 +20,11 @@ import {
 	Underline as UnderlineIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Emoji, type EmojiItem } from "./extensions/Emoji.ts";
 import { FabDash } from "./extensions/FabDash.ts";
 import "../../../styles/components/rich-text-editor.css";
 
-export interface EmojiItem {
-	name: string;
-	shortcodes: string[];
-	tags: string[];
-	group: string;
-	fallbackImage?: string;
-}
+export type { EmojiItem };
 
 export interface RichTextEditorProps {
 	content: Content | null;

--- a/src/platform/components/form/extensions/Emoji.ts
+++ b/src/platform/components/form/extensions/Emoji.ts
@@ -1,0 +1,185 @@
+import { InputRule, mergeAttributes, Node, PasteRule } from "@tiptap/core";
+
+/**
+ * Minimal stand-in for @tiptap/extension-emoji, kept local so we don't bundle
+ * its ~650KB default unicode emoji dataset — FABKIT only ever renders its own
+ * custom fallback-image icons (cost, power, etc.) and never the default set.
+ */
+
+export interface EmojiItem {
+	name: string;
+	shortcodes: string[];
+	tags: string[];
+	group: string;
+	fallbackImage?: string;
+}
+
+export interface EmojiOptions {
+	HTMLAttributes: Record<string, unknown>;
+	emojis: EmojiItem[];
+}
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		emoji: {
+			setEmoji: (shortcode: string) => ReturnType;
+		};
+	}
+}
+
+const inputRegex = /:([a-zA-Z0-9_+-]+):$/;
+const pasteRegex = /(^|\s):([a-zA-Z0-9_+-]+):/g;
+
+function findEmoji(name: string, emojis: EmojiItem[]): EmojiItem | undefined {
+	return emojis.find(
+		(item) => name === item.name || item.shortcodes.includes(name),
+	);
+}
+
+export const Emoji = Node.create<EmojiOptions>({
+	name: "emoji",
+
+	inline: true,
+	group: "inline",
+	selectable: false,
+
+	addOptions() {
+		return {
+			HTMLAttributes: {},
+			emojis: [],
+		};
+	},
+
+	addAttributes() {
+		return {
+			name: {
+				default: null,
+				parseHTML: (element) => element.dataset.name,
+				renderHTML: (attributes) => ({
+					"data-name": attributes.name,
+				}),
+			},
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: `span[data-type="${this.name}"]` }];
+	},
+
+	renderHTML({ HTMLAttributes, node }) {
+		const emojiItem = findEmoji(node.attrs.name, this.options.emojis);
+		const attributes = mergeAttributes(
+			HTMLAttributes,
+			this.options.HTMLAttributes,
+			{ "data-type": this.name },
+		);
+
+		if (!emojiItem?.fallbackImage) {
+			return ["span", attributes, `:${node.attrs.name}:`];
+		}
+
+		return [
+			"span",
+			attributes,
+			[
+				"img",
+				{
+					src: emojiItem.fallbackImage,
+					draggable: "false",
+					loading: "lazy",
+					align: "absmiddle",
+					alt: `${emojiItem.name} emoji`,
+				},
+			],
+		];
+	},
+
+	renderText({ node }) {
+		return `:${node.attrs.name}:`;
+	},
+
+	addCommands() {
+		return {
+			setEmoji:
+				(shortcode) =>
+				({ chain }) => {
+					const emojiItem = findEmoji(shortcode, this.options.emojis);
+
+					if (!emojiItem) {
+						return false;
+					}
+
+					return chain()
+						.insertContent({
+							type: this.name,
+							attrs: { name: emojiItem.name },
+						})
+						.command(({ tr, state }) => {
+							tr.setStoredMarks(
+								state.doc.resolve(state.selection.to - 1).marks(),
+							);
+							return true;
+						})
+						.run();
+				},
+		};
+	},
+
+	addInputRules() {
+		return [
+			new InputRule({
+				find: inputRegex,
+				handler: ({ range, match, chain }) => {
+					const name = match[1];
+
+					if (!findEmoji(name, this.options.emojis)) {
+						return;
+					}
+
+					chain()
+						.insertContentAt(range, { type: this.name, attrs: { name } })
+						.command(({ tr, state }) => {
+							tr.setStoredMarks(
+								state.doc.resolve(state.selection.to - 1).marks(),
+							);
+							return true;
+						})
+						.run();
+				},
+			}),
+		];
+	},
+
+	addPasteRules() {
+		return [
+			new PasteRule({
+				find: pasteRegex,
+				handler: ({ range, match, chain }) => {
+					const prefix = match[1] || "";
+					const name = match[2];
+
+					if (!findEmoji(name, this.options.emojis)) {
+						return;
+					}
+
+					const shortcodeFrom = range.from + prefix.length;
+					const shortcodeTo = range.to;
+
+					chain()
+						.insertContentAt(
+							{ from: shortcodeFrom, to: shortcodeTo },
+							{ type: this.name, attrs: { name } },
+							{ updateSelection: false },
+						)
+						.command(({ tr, state }) => {
+							tr.setStoredMarks(
+								state.doc.resolve(state.selection.to - 1).marks(),
+							);
+							return true;
+						})
+						.run();
+				},
+			}),
+		];
+	},
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,13 +17,6 @@ export default defineConfig({
 	},
 	build: {
 		sourcemap: true,
-		rolldownOptions: {
-			output: {
-				advancedChunks: {
-					groups: [{ name: "tiptap-emoji", test: /@tiptap\/extension-emoji/ }],
-				},
-			},
-		},
 	},
 	plugins: [
 		tsconfigPaths(),


### PR DESCRIPTION
Drops the package's bundled default emoji dataset (~650KB), which was always overridden with our own custom icons and never used. Adds a small local Emoji node extension covering only what we use: setEmoji command, :shortcode: input/paste rules, and fallback-image rendering.

Also removes the now-unneeded tiptap-emoji manualChunk grouping.