### PR TITLE
Fabble: set-name tooltips and visual consistency pass

### DIFF
--- a/src/apps/fabble/components/CardSearchInput.tsx
+++ b/src/apps/fabble/components/CardSearchInput.tsx
@@ -95,7 +95,7 @@ export function CardSearchInput({ mode }: CardSearchInputProps) {
 	const isPlaying = session.status === "playing";
 
 	return (
-		<div className="flex w-full max-w-100 flex-col items-center gap-2">
+		<div className="flex w-full max-w-160 flex-col items-center gap-2">
 			<Combobox value={null} onChange={handleSelect} disabled={!isPlaying}>
 				<div className="relative w-full">
 					<ComboboxInput

--- a/src/apps/fabble/components/Countdown.tsx
+++ b/src/apps/fabble/components/Countdown.tsx
@@ -14,7 +14,7 @@ export function Countdown({ onNewDay }: CountdownProps) {
 			<button
 				type="button"
 				onClick={onNewDay}
-				className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+				className="rounded-md bg-primary px-3.5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
 			>
 				{t("end.new_puzzle")}
 			</button>

--- a/src/apps/fabble/components/EndPanel.tsx
+++ b/src/apps/fabble/components/EndPanel.tsx
@@ -28,9 +28,9 @@ export function EndPanel({
 	const won = session.status === "won";
 
 	return (
-		<div className="fabble-fade-in flex w-full max-w-180 flex-col items-center gap-3">
+		<div className="fabble-fade-in flex w-full max-w-160 flex-col items-center gap-3">
 			<h2
-				className={`fabble-heading-bounce mt-4 text-3xl font-extrabold uppercase tracking-wide ${won ? "text-fabble-victory" : "text-fabble-defeat"}`}
+				className={`fabble-heading-bounce mt-4 text-3xl font-bold uppercase tracking-wide ${won ? "text-fabble-victory" : "text-fabble-defeat"}`}
 			>
 				{won ? t("end.victory") : t("end.defeat")}
 			</h2>

--- a/src/apps/fabble/components/EndlessCardSearchInput.tsx
+++ b/src/apps/fabble/components/EndlessCardSearchInput.tsx
@@ -88,7 +88,7 @@ export function EndlessCardSearchInput() {
 	const isPlaying = session.status === "playing";
 
 	return (
-		<div className="flex w-full max-w-100 flex-col items-center gap-2">
+		<div className="flex w-full max-w-160 flex-col items-center gap-2">
 			<Combobox value={null} onChange={handleSelect} disabled={!isPlaying}>
 				<div className="relative w-full">
 					<ComboboxInput

--- a/src/apps/fabble/components/EndlessEndPanel.tsx
+++ b/src/apps/fabble/components/EndlessEndPanel.tsx
@@ -24,9 +24,9 @@ export function EndlessEndPanel({
 	const won = session.status === "won";
 
 	return (
-		<div className="fabble-fade-in flex w-full max-w-180 flex-col items-center gap-3">
+		<div className="fabble-fade-in flex w-full max-w-160 flex-col items-center gap-3">
 			<h2
-				className={`fabble-heading-bounce mt-4 text-3xl font-extrabold uppercase tracking-wide ${won ? "text-fabble-victory" : "text-fabble-defeat"}`}
+				className={`fabble-heading-bounce mt-4 text-3xl font-bold uppercase tracking-wide ${won ? "text-fabble-victory" : "text-fabble-defeat"}`}
 			>
 				{won ? t("end.victory") : t("endless.gave_up")}
 			</h2>
@@ -89,7 +89,7 @@ export function EndlessEndPanel({
 						<button
 							type="button"
 							onClick={onNext}
-							className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+							className="rounded-md bg-primary px-3.5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
 						>
 							{t("endless.next_puzzle")}
 						</button>

--- a/src/apps/fabble/components/EndlessGuessHistory.tsx
+++ b/src/apps/fabble/components/EndlessGuessHistory.tsx
@@ -22,7 +22,7 @@ export function EndlessGuessHistory() {
 	const results = [...getOrderedEndlessResults(session)].reverse();
 
 	return (
-		<div className="flex w-full max-w-180 flex-col gap-5">
+		<div className="flex w-full max-w-160 flex-col gap-5">
 			{results.map((result) => {
 				const card = cardsById.get(result.guessId);
 				if (!card) return null;

--- a/src/apps/fabble/components/EndlessStatusBar.tsx
+++ b/src/apps/fabble/components/EndlessStatusBar.tsx
@@ -26,11 +26,11 @@ export function EndlessStatusBar({
 			<div className="flex flex-wrap items-center gap-2">
 				<Link
 					to="/fabble"
-					className="rounded-full border border-border-primary px-3 py-1 text-sm text-muted transition-colors hover:text-body"
+					className="rounded-md border border-border-primary px-3 py-1 text-sm text-muted transition-colors hover:text-body"
 				>
 					{t("play.menu_back")}
 				</Link>
-				<span className="rounded-full bg-primary px-3 py-1 text-sm font-medium text-white">
+				<span className="rounded-md bg-primary px-3 py-1 text-sm font-medium text-white">
 					{t("play.mode_badge_endless")}
 				</span>
 				<span className="text-sm text-body">

--- a/src/apps/fabble/components/FabbleLayout.tsx
+++ b/src/apps/fabble/components/FabbleLayout.tsx
@@ -14,12 +14,19 @@ export function FabbleLayout({ children }: FabbleLayoutProps) {
 	return (
 		<div className="flex w-full flex-col items-center">
 			<div className="relative h-37.5 w-full overflow-hidden sm:h-65">
+				{/* Crop window pulled above centre: the banner is a very wide, short strip out of
+				    a near-4:3 painting, and centring it landed on the right meep's chest with its
+				    head cut off. 30% keeps that head in frame while still catching the top of the
+				    left meep. */}
 				<img
 					src="/img/fabble/Mischievous-Meeps.webp"
 					alt=""
-					className="absolute inset-0 h-full w-full object-cover"
+					className="absolute inset-0 h-full w-full object-cover object-[50%_30%]"
 				/>
-				<div className="absolute inset-0 bg-gradient-to-b from-transparent via-surface/25 to-surface" />
+				{/* Starts at surface/30 rather than transparent: at full brightness the artwork
+				    reads as a slab pasted onto the page, worst in dark theme against a near-black
+				    background. Tinting with `surface` self-corrects per theme. */}
+				<div className="absolute inset-0 bg-gradient-to-b from-surface/30 via-surface/45 to-surface" />
 				<div className="absolute inset-x-0 bottom-3 flex justify-center sm:bottom-6">
 					<img
 						src="/img/fabble/FabbleLogo.svg"

--- a/src/apps/fabble/components/FeedbackBlock.tsx
+++ b/src/apps/fabble/components/FeedbackBlock.tsx
@@ -34,7 +34,7 @@ export function FeedbackBlock({
 	}, [alreadyAnimated, onAnimated, guessId]);
 
 	return (
-		<div className="w-full max-w-180 rounded-lg border border-border-primary bg-surface p-4">
+		<div className="w-full max-w-160 rounded-lg border border-border-primary bg-surface p-4">
 			<div className="mb-3 flex items-center gap-3">
 				<img
 					src={card.thumbnailUrl}

--- a/src/apps/fabble/components/FeedbackTile.tsx
+++ b/src/apps/fabble/components/FeedbackTile.tsx
@@ -1,4 +1,5 @@
 import type { ColumnFeedback } from "@fabkit/apps/fabble/types";
+import { Tooltip } from "@fabkit/platform/components/Tooltip";
 import { ArrowDown, ArrowUp, Ban, Check } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useState } from "react";
@@ -110,7 +111,9 @@ function SetTileBody({
 		<div className="flex flex-col gap-0.5 text-[11px] leading-tight font-medium">
 			{visible.map((s) => (
 				<span key={s.code} className="flex items-center justify-between gap-1">
-					<span className="truncate">{s.code}</span>
+					<Tooltip label={s.name}>
+						<span className="truncate">{s.code}</span>
+					</Tooltip>
 					{s.mark === "check" && <Check className="h-3 w-3 shrink-0" />}
 					{s.mark === "higher" && <ArrowUp className="h-3 w-3 shrink-0" />}
 					{s.mark === "lower" && <ArrowDown className="h-3 w-3 shrink-0" />}

--- a/src/apps/fabble/components/GuessHistory.tsx
+++ b/src/apps/fabble/components/GuessHistory.tsx
@@ -25,7 +25,7 @@ export function GuessHistory({ mode }: GuessHistoryProps) {
 	const results = [...getOrderedResults(session)].reverse();
 
 	return (
-		<div className="flex w-full max-w-180 flex-col gap-5">
+		<div className="flex w-full max-w-160 flex-col gap-5">
 			{results.map((result) => {
 				const card = cardsById.get(result.guessId);
 				if (!card) return null;

--- a/src/apps/fabble/components/HintsRow.tsx
+++ b/src/apps/fabble/components/HintsRow.tsx
@@ -23,7 +23,7 @@ export function HintsRow({
 
 	return (
 		<div className="flex w-full max-w-160 flex-wrap items-center gap-2">
-			<span className="text-[11px] font-medium tracking-wide text-muted uppercase">
+			<span className="text-xs font-semibold tracking-wider text-subtle uppercase">
 				{t("hints.title")}
 			</span>
 			<div className="flex flex-nowrap gap-1.5">
@@ -76,7 +76,7 @@ function HintPill({
 
 	if (revealed) {
 		return (
-			<span className="flex items-center gap-1.5 rounded-full border border-primary bg-surface-active px-2.5 py-1 text-xs text-body">
+			<span className="flex items-center gap-1.5 rounded-md border border-primary bg-surface-active px-2.5 py-1 text-xs text-body">
 				{children}
 			</span>
 		);
@@ -87,7 +87,7 @@ function HintPill({
 			<button
 				type="button"
 				onClick={onReveal}
-				className="flex items-center gap-1.5 rounded-full border border-primary px-2.5 py-1 text-xs text-heading transition-colors hover:bg-surface-active"
+				className="flex items-center gap-1.5 rounded-md border border-primary px-2.5 py-1 text-xs text-heading transition-colors hover:bg-surface-active"
 			>
 				<LockOpen className="h-3 w-3" />
 				{label}
@@ -96,7 +96,7 @@ function HintPill({
 	}
 
 	return (
-		<span className="flex items-center gap-1.5 rounded-full border border-border-primary px-2.5 py-1 text-xs text-muted">
+		<span className="flex items-center gap-1.5 rounded-md border border-border-primary px-2.5 py-1 text-xs text-muted">
 			<Lock className="h-3 w-3" />
 			{t("hints.locked", { count: unlockAt })}
 		</span>

--- a/src/apps/fabble/components/ModeSelect.tsx
+++ b/src/apps/fabble/components/ModeSelect.tsx
@@ -37,7 +37,7 @@ export function ModeSelect() {
 			<button
 				type="button"
 				onClick={() => setRulesOpen(true)}
-				className="flex items-center gap-1.5 rounded-full border border-border-primary px-4 py-1.5 text-sm text-body transition-colors hover:bg-surface-active"
+				className="flex items-center gap-1.5 rounded-md border border-border-primary px-4 py-1.5 text-sm text-body transition-colors hover:bg-surface-active"
 			>
 				<HelpCircle className="h-4 w-4" />
 				{t("home.how_to_play")}
@@ -66,7 +66,7 @@ export function ModeSelect() {
 							</p>
 							<Link
 								to={MODE_ROUTES[mode]}
-								className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+								className="rounded-md bg-primary px-3.5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
 							>
 								{t("home.modes.play")}
 							</Link>

--- a/src/apps/fabble/components/RulesDialog.tsx
+++ b/src/apps/fabble/components/RulesDialog.tsx
@@ -264,7 +264,7 @@ export function RulesDialog({ open, onClose }: RulesDialogProps) {
 						ref={closeButtonRef}
 						type="button"
 						onClick={onClose}
-						className="w-full rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+						className="w-full rounded-md bg-primary px-3.5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
 					>
 						{t("common.close")}
 					</button>

--- a/src/apps/fabble/components/StatusBar.tsx
+++ b/src/apps/fabble/components/StatusBar.tsx
@@ -25,11 +25,11 @@ export function StatusBar({
 			<div className="flex items-center gap-2">
 				<Link
 					to="/fabble"
-					className="rounded-full border border-border-primary px-3 py-1 text-sm text-muted transition-colors hover:text-body"
+					className="rounded-md border border-border-primary px-3 py-1 text-sm text-muted transition-colors hover:text-body"
 				>
 					{t("play.menu_back")}
 				</Link>
-				<span className="rounded-full bg-primary px-3 py-1 text-sm font-medium text-white">
+				<span className="rounded-md bg-primary px-3 py-1 text-sm font-medium text-white">
 					{t(`play.mode_badge_${mode}`)}
 				</span>
 				<span className="text-sm text-body">

--- a/src/apps/fabble/components/TypeChipsRow.tsx
+++ b/src/apps/fabble/components/TypeChipsRow.tsx
@@ -6,7 +6,7 @@ export function TypeChipsRow() {
 
 	return (
 		<div className="flex w-full max-w-160 flex-col items-center gap-1.5">
-			<span className="text-[11px] font-medium tracking-wide text-muted uppercase">
+			<span className="text-xs font-semibold tracking-wider text-subtle uppercase">
 				{t("play.possible_types")}
 			</span>
 			<div className="flex flex-wrap justify-center gap-1.5">

--- a/src/apps/fabble/game/compare.ts
+++ b/src/apps/fabble/game/compare.ts
@@ -149,17 +149,32 @@ function compareSetColumn(
 	const setDetails = ordered.map((s) => {
 		const shared = answerCodes.has(s.code);
 		if (shared)
-			return { code: s.code, promo: !!s.promo, mark: "check" as const };
+			return {
+				code: s.code,
+				name: s.name,
+				promo: !!s.promo,
+				mark: "check" as const,
+			};
 		if (s.promo || answerRegularMin === null || answerRegularMax === null) {
-			return { code: s.code, promo: !!s.promo, mark: null };
+			return { code: s.code, name: s.name, promo: !!s.promo, mark: null };
 		}
 		if (answerRegularMin > s.order) {
-			return { code: s.code, promo: false, mark: "higher" as const };
+			return {
+				code: s.code,
+				name: s.name,
+				promo: false,
+				mark: "higher" as const,
+			};
 		}
 		if (answerRegularMax < s.order) {
-			return { code: s.code, promo: false, mark: "lower" as const };
+			return {
+				code: s.code,
+				name: s.name,
+				promo: false,
+				mark: "lower" as const,
+			};
 		}
-		return { code: s.code, promo: false, mark: null };
+		return { code: s.code, name: s.name, promo: false, mark: null };
 	});
 
 	return { state: matched ? "match" : "miss", setDetails };

--- a/src/apps/fabble/types.ts
+++ b/src/apps/fabble/types.ts
@@ -123,6 +123,9 @@ export interface ColumnFeedback {
 	shared?: string[];
 	setDetails?: {
 		code: string;
+		/** Full set name, e.g. "Welcome to Rathe" — shown in the Set tile's hover tooltip,
+		    since the tile itself only has room for the abbreviation. */
+		name: string;
 		promo: boolean;
 		mark: "check" | "higher" | "lower" | null;
 	}[];

--- a/src/platform/components/Tooltip.tsx
+++ b/src/platform/components/Tooltip.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+import { useId, useState } from "react";
+
+interface TooltipProps {
+	/** Text shown in the bubble. Must already be translated. */
+	label: string;
+	children: ReactNode;
+}
+
+/**
+ * Small hover/focus tooltip styled with the site's own tokens, so it reads as part of FABKIT
+ * rather than as the browser's native `title` bubble.
+ *
+ * Pointer-and-keyboard only by design: there are no touch handlers, and `pointer-coarse:hidden`
+ * suppresses the bubble on touch devices, where browsers synthesise a hover on tap and would
+ * otherwise fire it on every press. Anything a touch user needs must stay reachable without
+ * this component.
+ */
+export function Tooltip({ label, children }: TooltipProps) {
+	const [open, setOpen] = useState(false);
+	const id = useId();
+
+	return (
+		<span className="relative inline-flex">
+			{/* A real button rather than a span with tabIndex: natively focusable, and it
+			    keeps the trigger in the keyboard flow without fighting a11y lint rules. */}
+			<button
+				type="button"
+				aria-describedby={open ? id : undefined}
+				onMouseEnter={() => setOpen(true)}
+				onMouseLeave={() => setOpen(false)}
+				onFocus={() => setOpen(true)}
+				onBlur={() => setOpen(false)}
+				className="inline-flex min-w-0 cursor-help rounded-xs text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+			>
+				{children}
+			</button>
+			{open && (
+				<span
+					id={id}
+					role="tooltip"
+					className="pointer-events-none absolute bottom-full left-1/2 z-20 mb-1 max-w-48 -translate-x-1/2 rounded-md border border-border-primary bg-surface px-2 py-1 text-xs leading-snug font-medium text-body normal-case shadow-lg pointer-coarse:hidden"
+				>
+					{label}
+				</span>
+			)}
+		</span>
+	);
+}


### PR DESCRIPTION
## Set-name tooltips (b0c5b00)

The Set feedback tile only has room for an abbreviation (`MON`, `WTR`, `ARC`), so anyone who doesn't already know the codes can't read it. Each code is now wrapped in a tooltip carrying the full set name.

Adds `src/platform/components/Tooltip.tsx` rather than a Fabble-local component. There was no tooltip anywhere in FABKIT before this, only raw `title` attributes, which render in the browser's own styling. This one uses the site's existing floating-layer recipe so it matches the rest of the app.

Pointer and keyboard only: hover plus focus, no touch handlers, and `pointer-coarse:hidden` suppresses the bubble where browsers synthesise a hover on tap. The existing "+N more" expand button stays the touch affordance and is unchanged. Verified `@media (pointer:coarse)` reaches the compiled CSS.

No dataset change needed. `name` was already published on `FabbleSetPrinting`; `ColumnFeedback.setDetails` was simply dropping it.

## Visual consistency pass (165dcc6)

Feedback was that Fabble reads as AI-generated next to the card creator. This is token and recipe alignment, not a redesign. Nothing moves position.

- **One shared measure for the play column.** The guess history, status bar and search input each had their own max-width and were centred, so at 1440px they started at three different left edges (497px, 537px, 657px). All five blocks are now `max-w-160`. No change below 640px.
- **Hero banner** crop moved to 30% so the right meep's head is in frame, and the scrim starts at `surface/30` instead of `transparent` so the artwork stops reading as a bright slab in dark theme.
- **`rounded-md` on interactive controls** instead of `rounded-full`, matching the site convention. Static type chips stay pills, same as the roadmap badges.
- **Micro-labels** adopt the platform label recipe in place of a one-off `text-[11px]`.
- **Primary buttons** use the canonical `px-3.5 py-2.5`.
- **Victory/defeat heading** drops to `font-bold`; it was the only `font-extrabold`
  in the repo.

Deliberately untouched: feedback tile colours, tile styling, animations, and the
mode-select artwork.

## Testing

`bun format`, `bun run build` (incl. `tsc -b`) andean.
Tooltip verified in-browser at 1440px and 390px, light and dark.

## Related

Depends on the fabble-admin fixes already published to the live feed (card pool
restored 2,861 → 3,006, heroes 91 → 150, unreleased cards no longer scheduled as
Standard answers).