### PR TITLE
Add url params for card builder

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,52 @@
+# FABKIT
+
+Browser-based tools for the Flesh and Blood TCG. This glossary fixes the words used across the codebase, docs, and UI copy, so the same concept is never named two ways.
+
+## Language
+
+### Card creator
+
+**Card Creator**:
+The app in which a user composes a Flesh and Blood card and exports it as an image.
+_Avoid_: custom card builder, card builder, card maker
+
+**Frame**:
+The bordered card template that artwork and text are composed onto. Its type and style decide which frame images are available. Stored as `CardBack`, and surfaced in the UI as the background.
+_Avoid_: border, cardback (as two words or hyphenated)
+
+**Custom Frame**:
+A frame image uploaded by the user rather than shipped with the app. In this codebase *custom* means this and nothing else, so a user-made card is never a "custom card".
+_Avoid_: custom card, custom background, user frame
+
+**Card Type**:
+What the card is in the game (action, hero, weapon, and so on). It decides which form fields are visible and which frames are compatible.
+
+**Card Style**:
+The visual variant of a frame, independent of card type.
+
+**Pitch**:
+The colour of a card's pitch value, one of three. Distinct from cost.
+_Avoid_: pitch cost, pitch value
+
+**Cost**:
+The resource cost to play the card. Distinct from pitch, despite living under the `CardResource` key.
+_Avoid_: resource, resource cost
+
+**Hybrid**:
+A card whose frame is two frames joined at a vertical seam. A card is hybrid exactly when a right-hand frame is set; there is no separate flag.
+
+**Meld Half**:
+One of the two independently composed sides of a meld card. Each half carries its own type, name, artwork, and text.
+_Avoid_: side, panel, face
+
+**Prefill Link**:
+A URL that opens the Card Creator with fields already filled in, built by an application outside FABKIT. It carries a card's composition, never a saved card's identity.
+_Avoid_: share link, import link, deep link
+
+### Gallery
+
+**Gallery**:
+The user's local collection of saved cards, held in the browser rather than on a server.
+
+**Folder**:
+A named grouping of saved cards in the gallery. Identified to the user by its path, not by its internal id.

--- a/docs/adr/0001-prefill-links-use-readable-params.md
+++ b/docs/adr/0001-prefill-links-use-readable-params.md
@@ -1,0 +1,11 @@
+# Prefill links use readable params, not an encoded payload
+
+A link that opens the Card Creator with fields already filled in carries its values as named query params (`?type=action&name=Sink+Below&pitch=3`) rather than an encoded blob of card state. The consumer is an application outside FABKIT building a link from documentation, and readable params let it do that without depending on FABKIT internals.
+
+## Considered options
+
+Encoding `SerializedCardState` as `base64url(gzip(json))` in a single param was rejected. It is only producible by code that imports the serializer, and it would create a second wire format to version and migrate alongside the stored one. Exact-fidelity card sharing is already served by `.fabkit` export, which is a different feature to a prefill link.
+
+## Consequences
+
+The param names are a public API. They are append-only: a param is never renamed or removed, which is why there is no version param to bump.

--- a/docs/adr/0002-prefill-link-text-is-plain-text.md
+++ b/docs/adr/0002-prefill-link-text-is-plain-text.md
@@ -1,0 +1,9 @@
+# Prefill link card text is plain text, never HTML
+
+The `text` param accepts plain text with `:cost:` style shortcodes and `**bold**` shorthand, and is converted into a Tiptap document, from which the HTML is generated. HTML is never accepted from a link.
+
+The shorthand is interpreted, never passed through. The converter reads `:name:` and `**`, and decides for itself which nodes and marks the document contains; a link that writes `<b>` puts those three characters on the card. Both shorthands are the ones the editor's own input rules already recognise, so a link author and a user typing at the keyboard produce the same document.
+
+`CardTextHTML` is passed to `dangerouslySetInnerHTML` by both `NormalRenderer` and `MeldRenderer`, so a param able to set it directly would be a scripting vector on the site. Keeping that value editor-produced means the surface never opens and no sanitiser sits on the critical path. Shortcodes cost external consumers nothing, since `extensions/Emoji.ts` already treats `:name:` as the canonical text form of a game symbol.
+
+A reader finding the plain-text to Tiptap converter may wonder why the param does not simply set `CardTextHTML`. This is why.

--- a/docs/adr/0003-prefill-link-artwork-has-no-host-allowlist.md
+++ b/docs/adr/0003-prefill-link-artwork-has-no-host-allowlist.md
@@ -1,0 +1,13 @@
+# Prefill link artwork accepts any https host
+
+The `art` param takes an image URL, which is fetched to a Blob and handed to `setCardArtwork`. Any `https` host is accepted, bounded by a size ceiling, with no allowlist of permitted image hosts.
+
+## Considered options
+
+An allowlist was rejected because it does not address either real risk. Opening a link makes the recipient's browser reach an attacker-chosen host, disclosing IP and user agent, and a hand-crafted link can render arbitrary imagery inside a page that looks like FABKIT. Both work exactly as well from an allowlisted image host, so an allowlist would cost reach and ongoing maintenance while looking like a security control that it is not.
+
+## Consequences
+
+The URL is fetched to a Blob rather than placed in the SVG `image` href. This is deliberate: the renderer resolves the Blob to a same-origin `blob:` URL, so snapdom never captures a cross-origin image and PNG export cannot be broken by a tainted canvas. Placing the remote URL in the href directly would reintroduce that.
+
+The source host must send `Access-Control-Allow-Origin`, since an opaque `no-cors` response yields an unusable blob. Support has to be confirmed per host. Any failure surfaces in the ignored-params notice and the card still opens with everything else applied.

--- a/docs/prefill-links.md
+++ b/docs/prefill-links.md
@@ -1,0 +1,160 @@
+# Prefill links
+
+A prefill link opens the FABKIT Card Creator with fields already filled in. Any
+application can build one: it is a plain URL with named query params, and needs
+no code from FABKIT.
+
+```
+https://fabkit.io/#/card-creator?type=action&name=Sink+Below&pitch=3&cost=0&defense=3&class=ninja&text=%3Adefense%3A+Instant
+```
+
+A prefill link carries a card's composition, not a saved card's identity. For
+an exact copy of a card, including its artwork and frame, use the Card
+Creator's own `.fabkit` export instead.
+
+## Where the params go
+
+FABKIT uses hash routing, so the query string goes **inside** the hash, after
+the route:
+
+```
+https://fabkit.io/#/card-creator?type=hero&name=Dorinthea       correct
+https://fabkit.io/?type=hero&name=Dorinthea#/card-creator       ignored
+```
+
+Values are URL-encoded as usual: `+` or `%20` for a space, `%3A` for the colons
+around a shortcode, `%0A` for a line break.
+
+## What happens when the link opens
+
+The card is composed before the page is first drawn, and the params are then
+removed from the address bar. The link applies once: nothing in it is re-applied
+over the user's own edits afterwards, and the URL they can copy is a plain Card
+Creator URL rather than your link.
+
+The card lives in the page until the user saves it, so reloading starts an empty
+Card Creator rather than reopening the link.
+
+Anything in the link that cannot be applied is skipped, and the Card Creator
+shows the user which params those were and why. The rest of the link still
+applies: one bad param never costs you the whole card.
+
+## Params
+
+| Param | Sets | Accepted values |
+|---|---|---|
+| `type` | Card type | Any card type except `meld` |
+| `style` | Frame style | `dented`, `flat` |
+| `frame` | Frame | A frame name, case-insensitive |
+| `frame2` | Right-hand frame | A frame name; setting it is what makes the card hybrid |
+| `split` | Hybrid seam position | Whole number 2 to 98, percent across the card |
+| `blend` | Hybrid seam softness | Whole number 0 to 100, percent of the widest blend |
+| `name` | Card name | Any text |
+| `pitch` | Pitch colour | `1`, `2`, `3` |
+| `cost` | Resource cost | Any text |
+| `power` | Power | Any text |
+| `defense` | Defense | Any text |
+| `life` | Life | Any text |
+| `intellect` | Intellect | Any text |
+| `class` | Class | A class name, e.g. `ninja` |
+| `class2` | Second class | A class name |
+| `talent` | Talent | A talent name, e.g. `shadow` |
+| `subtype` | Subtype | Any text |
+| `rarity` | Rarity | A rarity name, e.g. `majestic` |
+| `weapon` | Weapon hands | `1h`, `2h` |
+| `group` | Macro group | Any text |
+| `text` | Card text | Plain text, with line breaks, `**bold**`, and `:shortcode:` symbols |
+| `artist` | Artist credit | Any text |
+| `setnumber` | Set number | Any text, shown uppercased |
+| `art` | Artwork | An `https` image URL |
+
+`pitch` is the card's pitch **colour**; `cost` is what it costs to play. The
+Card Creator labels them Pitch and Cost.
+
+Param names are lowercase. Any value that names something (`type`, `style`,
+`class`, `class2`, `talent`, `rarity`, `weapon`, `frame`, `frame2`) is matched
+case-insensitively, so `class=Ninja` and `class=ninja` are the same. Free text
+is used exactly as you write it, apart from surrounding whitespace.
+
+Param names never change and are never removed, so a published link keeps
+working. That is also why there is no version param.
+
+### Fields the card type doesn't have
+
+Each card type shows its own set of fields: a hero has no pitch, an action has
+no intellect. A param for a field the chosen type doesn't show is skipped and
+reported, so set `type` first and build the rest of the link around it.
+
+## Frames
+
+`frame` and `frame2` take a frame's name, matched within the card type and
+style the link asks for. Names repeat across types (Aria is both a general
+frame and a hero frame), which is why `type` and `style` are what make a name
+resolve to one frame.
+
+The names are the ones the Card Creator's frame picker shows for that type and
+style. A name that doesn't match is skipped and reported, and the card opens
+with the frame that type and style would normally start on.
+
+Some card types have frames in only one style: a weapon has no flat frames, for
+instance. Asking for a style a type has no frames in opens the style that does
+have them, and says so.
+
+Custom frames, the ones a user uploads themselves, are never matched. They
+exist only in that person's browser, so a public link resolving against one
+would pick up whatever the recipient happened to upload under the same name.
+
+### Hybrid cards
+
+A card is hybrid exactly when it has a right-hand frame, so `frame2` is what
+turns hybrid on. `frame2` on its own is fine: the left frame falls back to the
+default for the type and style.
+
+`split` and `blend` only mean anything on a hybrid card, so both are skipped
+and reported if the link has no `frame2`. Both are whole percentages, and a
+value outside the range is skipped rather than quietly pulled into it.
+
+```
+https://fabkit.io/#/card-creator?type=action&frame=aria&frame2=assassin&split=40&blend=60
+```
+
+## Card text
+
+`text` is plain text. Line breaks start a new paragraph, and game symbols are
+written as shortcodes:
+
+`:cost:` `:power:` `:defense:` `:life:` `:intellect:` `:tap:` `:untap:` `:chi:`
+
+A shortcode that isn't one of these stays as literal text, the same as it would
+if a user typed it into the editor.
+
+Bold is written `**like this**` or `__like this__`, the same shorthand the
+editor turns into bold as you type. The opening delimiter has to start the line
+or follow a space, so an underscore inside a word is left alone, and a
+delimiter with no closing partner stays as literal characters. Italic and
+underline have no shorthand in a link; apply those in the editor.
+
+HTML is never accepted here. `<b>bold</b>` in a link arrives on the card as
+those exact characters, angle brackets included.
+
+## Artwork
+
+`art` takes an `https` image URL, which FABKIT downloads and places on the
+card. Two things decide whether it works:
+
+- **The host must allow cross-origin reads.** The response needs an
+  `Access-Control-Allow-Origin` header that permits fabkit.io. Many image hosts
+  and CDNs do; many do not, and there is no way to tell without trying. Check
+  the host you plan to use before publishing links that depend on it.
+- **The image must be under 32 MB.**
+
+If the image can't be fetched, for any reason, the card still opens with
+everything else applied and the user is told the artwork was skipped.
+
+Once the user saves the card, the image is stored in their browser, so the card
+survives the source URL going away.
+
+## Not addressable
+
+Meld cards, custom frames, and the artwork's position and crop cannot be set
+from a link.

--- a/src/apps/card-creator/CLAUDE.md
+++ b/src/apps/card-creator/CLAUDE.md
@@ -25,6 +25,7 @@ src/apps/card-creator/
     migrations/        # Per-version data migrations
   stores/
     card-creator.ts    # Zustand store (useCardCreator)
+  url-params/          # Prefill links: the public param vocabulary and how a link becomes card state
   index.ts             # App entry — registers bug-report data provider
 ```
 

--- a/src/apps/card-creator/components/card-creator/PrefillNotice.tsx
+++ b/src/apps/card-creator/components/card-creator/PrefillNotice.tsx
@@ -1,0 +1,44 @@
+import {
+	dismissPrefillNotice,
+	usePrefillNotice,
+} from "@fabkit/apps/card-creator/url-params";
+import { AlertTriangle, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Tells the user which parts of a prefill link the card could not take.
+ * Silently dropping them would leave the developer who built the link
+ * debugging blind, and refusing the whole link would punish the user for
+ * someone else's typo.
+ */
+export const PrefillNotice = () => {
+	const { t } = useTranslation("card-creator");
+	const ignored = usePrefillNotice();
+
+	return ignored.length === 0 ? null : (
+		<div
+			role="status"
+			className="flex items-start gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-500"
+		>
+			<AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+			<div className="flex-1 space-y-1">
+				<p className="font-semibold">{t("card_creator.prefill.title")}</p>
+				<ul className="space-y-0.5">
+					{ignored.map(({ param, reason }) => (
+						<li key={`${param}-${reason}`}>
+							{t(`card_creator.prefill.ignored.${reason}`, { param })}
+						</li>
+					))}
+				</ul>
+			</div>
+			<button
+				type="button"
+				onClick={dismissPrefillNotice}
+				className="shrink-0 rounded-md p-1 transition-colors hover:bg-amber-500/20 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+			>
+				<span className="sr-only">{t("card_creator.prefill.dismiss")}</span>
+				<X aria-hidden="true" className="h-4 w-4" />
+			</button>
+		</div>
+	);
+};

--- a/src/apps/card-creator/i18n/en.json
+++ b/src/apps/card-creator/i18n/en.json
@@ -168,7 +168,20 @@
 		"custom_frame_action_label": "Add custom frame",
 		"custom_frame_badge": "custom",
 		"missing_frame_label": "Missing custom frame",
-		"missing_frame_warning": "This card uses a custom frame that isn't available on this device. It will still save correctly — re-add the frame later to restore it."
+		"missing_frame_warning": "This card uses a custom frame that isn't available on this device. It will still save correctly — re-add the frame later to restore it.",
+		"prefill": {
+			"title": "Some parts of this link were skipped",
+			"dismiss": "Dismiss",
+			"ignored": {
+				"unknown_param": "{{param}}: not a parameter the card creator recognises",
+				"invalid_value": "{{param}}: that value isn't accepted",
+				"not_on_card_type": "{{param}}: this card type doesn't have that field",
+				"needs_second_frame": "{{param}}: only applies when the link also sets frame2",
+				"unknown_frame": "{{param}}: no frame with that name for this card type and style",
+				"style_unavailable": "{{param}}: this card type has no frames in that style, so the other one was used",
+				"artwork_unavailable": "{{param}}: the image couldn't be loaded from that address"
+			}
+		}
 	},
 	"gallery": {
 		"title": "Saved Cards",

--- a/src/apps/card-creator/url-params/artwork.ts
+++ b/src/apps/card-creator/url-params/artwork.ts
@@ -1,0 +1,119 @@
+/**
+ * Fetches the image a prefill link's `art` param points at.
+ *
+ * Any https host is accepted, and the image is fetched to a Blob rather than
+ * pointed at from the SVG. See
+ * docs/adr/0003-prefill-link-artwork-has-no-host-allowlist.md for both
+ * decisions and what they cost.
+ */
+
+/**
+ * Ceiling on a fetched image. Generous enough for a print-resolution
+ * illustration, low enough that a link cannot make a phone download a
+ * gigabyte before anything is on screen.
+ */
+export const ARTWORK_MAX_BYTES = 32 * 1024 * 1024;
+
+/**
+ * How long a host gets before the card opens without its artwork. The route
+ * loader awaits this fetch, so an unresponsive host would otherwise hold back
+ * the whole page rather than one field.
+ */
+export const ARTWORK_TIMEOUT_MS = 10_000;
+
+const OVERSIZE_MESSAGE = "Artwork is larger than the size ceiling";
+
+/**
+ * http is rejected rather than upgraded: the browser blocks it as mixed
+ * content before the request starts, so accepting it would only turn a clear
+ * "this param is not usable" into a fetch that always fails.
+ */
+export const getArtworkUrl = (value: string): string | null => {
+	let url: string | null = null;
+
+	try {
+		const parsed = new URL(value);
+
+		if (parsed.protocol === "https:") {
+			url = parsed.href;
+		}
+	} catch {
+		// Not a URL at all, which for our purposes is indistinguishable from a
+		// URL we won't fetch.
+	}
+
+	return url;
+};
+
+/**
+ * Content-Length is advisory: absent on a chunked response, and free to lie.
+ * Reading the body in chunks drops an oversize image as soon as it crosses the
+ * ceiling, instead of after the whole download has already landed.
+ */
+const getBoundedBlob = async (response: Response): Promise<Blob> => {
+	if (response.body === null) {
+		throw new Error("Artwork response had no body");
+	}
+
+	const reader = response.body.getReader();
+	// A fetch body's chunks are never SharedArrayBuffer-backed, which is all
+	// Blob's parameter type asks for and all the DOM types decline to say.
+	const chunks: Uint8Array<ArrayBuffer>[] = [];
+	let receivedBytes = 0;
+	let isOversize = false;
+	let isComplete = false;
+
+	while (!isComplete && !isOversize) {
+		const { done, value } = await reader.read();
+
+		if (done) {
+			isComplete = true;
+		} else {
+			receivedBytes += value.byteLength;
+			isOversize = receivedBytes > ARTWORK_MAX_BYTES;
+
+			if (!isOversize) {
+				chunks.push(value as Uint8Array<ArrayBuffer>);
+			}
+		}
+	}
+
+	if (isOversize) {
+		await reader.cancel();
+		throw new Error(OVERSIZE_MESSAGE);
+	}
+
+	return new Blob(chunks, {
+		type: response.headers.get("content-type") ?? "",
+	});
+};
+
+/**
+ * Throws on anything that stops us producing a usable image: a CORS-less host
+ * (the opaque no-cors response's blob is unusable, so it is not a workaround),
+ * a 404, an abort, a host that never answers, or an image past the size
+ * ceiling. The caller turns that into a notice and opens the card without
+ * artwork.
+ */
+export const getArtworkBlob = async (
+	url: string,
+	signal: AbortSignal,
+): Promise<Blob> => {
+	// The timeout covers the body as well as the headers, since aborting the
+	// fetch errors the stream getBoundedBlob is reading.
+	const response = await fetch(url, {
+		signal: AbortSignal.any([signal, AbortSignal.timeout(ARTWORK_TIMEOUT_MS)]),
+	});
+
+	if (!response.ok) {
+		throw new Error(`Artwork request failed with status ${response.status}`);
+	}
+
+	const declaredBytes = Number(response.headers.get("content-length"));
+	if (declaredBytes > ARTWORK_MAX_BYTES) {
+		await response.body?.cancel();
+		throw new Error(OVERSIZE_MESSAGE);
+	}
+
+	return getBoundedBlob(response);
+};

--- a/src/apps/card-creator/url-params/index.ts
+++ b/src/apps/card-creator/url-params/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Prefill links: a URL that opens the card creator with fields already filled
+ * in, built by an application outside FABKIT.
+ *
+ * This module is the boundary. Nothing outside url-params/ should reach past
+ * it into the parser, the vocabulary, or the notice store.
+ *
+ * The order below is the part that is easy to get wrong. loadCard resets to
+ * initial state and merges raw, running none of the side effects the store's
+ * own setters do, so it must be called exactly once with everything parse.ts
+ * resolved. Artwork can only follow it: setCardArtwork is async and seeds
+ * CardArtPosition from the image's natural dimensions.
+ */
+
+import { v4 as uuid } from "uuid";
+import { useCardCreator } from "../stores/card-creator.ts";
+import { getArtworkBlob } from "./artwork.ts";
+import { setPrefillNotice } from "./notice.ts";
+import { parsePrefillParams } from "./parse.ts";
+import { getCardTextHTML } from "./text.ts";
+import type { IgnoredParam } from "./vocabulary.ts";
+
+export {
+	dismissPrefillNotice,
+	dismissStalePrefillNotice,
+	usePrefillNotice,
+} from "./notice.ts";
+export type { IgnoredParam } from "./vocabulary.ts";
+
+export const applyPrefillParams = async (
+	search: Record<string, unknown>,
+	signal: AbortSignal,
+): Promise<void> => {
+	const ignored: IgnoredParam[] = [];
+
+	try {
+		const parsed = parsePrefillParams(search);
+		ignored.push(...parsed.ignored);
+
+		const text =
+			parsed.textDoc === null
+				? {}
+				: {
+						CardTextNode: parsed.textDoc,
+						CardTextHTML: getCardTextHTML(parsed.textDoc),
+					};
+
+		// A link produces a card the gallery has never seen, so it needs its own
+		// __version. loadCard merges over the store's initial state, whose
+		// __version is minted once when the module loads and is therefore the id
+		// of whatever was saved earlier in this page's life; inheriting it would
+		// make the next Save update that row instead of adding one. reset() mints
+		// a fresh id for the same reason.
+		useCardCreator
+			.getState()
+			.loadCard({ ...parsed.patch, ...text, __version: uuid() });
+
+		if (parsed.artworkUrl !== null) {
+			try {
+				const artwork = await getArtworkBlob(parsed.artworkUrl, signal);
+				await useCardCreator.getState().setCardArtwork(artwork);
+			} catch {
+				// The host being unreachable, slow, or CORS-less is the common case
+				// and says nothing about the rest of the link, so the card still
+				// opens with everything else applied.
+				ignored.push({ param: "art", reason: "artwork_unavailable" });
+			}
+		}
+	} catch (error) {
+		// Anything reaching here is a fault in this code rather than a bad link:
+		// the parser is pure, and the only other step is serialising a document
+		// we built ourselves. It must not escape, because the caller strips the
+		// params immediately after this and would never get the chance, leaving
+		// them in the URL to be applied again on every later loader run.
+		console.error("Prefill link could not be applied", error);
+	}
+
+	setPrefillNotice(ignored);
+};

--- a/src/apps/card-creator/url-params/notice.ts
+++ b/src/apps/card-creator/url-params/notice.ts
@@ -1,0 +1,58 @@
+/**
+ * What a prefill link asked for that the card could not take, held for the
+ * banner that tells the user about it.
+ *
+ * Deliberately not loader data: applying a link ends in a replace navigation
+ * that strips the params, and that re-runs the loader against an empty search,
+ * discarding whatever the first pass returned. A store outlives the second
+ * pass; loader data does not.
+ */
+
+import { create } from "zustand";
+import type { IgnoredParam } from "./vocabulary.ts";
+
+interface PrefillNoticeState {
+	ignored: IgnoredParam[];
+}
+
+const usePrefillNoticeStore = create<PrefillNoticeState>(() => ({
+	ignored: [],
+}));
+
+/**
+ * Whether the notice belongs to a link the route is still in the middle of
+ * applying. The strip navigation runs the loader a second time, and that pass
+ * must not throw away what the first one just recorded.
+ */
+let isAwaitingStrip = false;
+
+export const setPrefillNotice = (ignored: IgnoredParam[]): void => {
+	isAwaitingStrip = true;
+	usePrefillNoticeStore.setState({ ignored });
+};
+
+export const dismissPrefillNotice = (): void => {
+	isAwaitingStrip = false;
+	usePrefillNoticeStore.setState({ ignored: [] });
+};
+
+/**
+ * Called when the route is entered with no params. That is either the strip
+ * navigation, which keeps the notice, or the user arriving without a link at
+ * all, in which case the notice describes a link that is no longer on screen
+ * and goes.
+ */
+export const dismissStalePrefillNotice = (): void => {
+	if (isAwaitingStrip) {
+		isAwaitingStrip = false;
+	} else {
+		dismissPrefillNotice();
+	}
+};
+
+export const usePrefillNotice = (): IgnoredParam[] =>
+	usePrefillNoticeStore((state) => state.ignored);
+
+/** Non-React read, matching the convention custom-frames.ts sets. */
+export const getPrefillNotice = (): IgnoredParam[] =>
+	usePrefillNoticeStore.getState().ignored;

--- a/src/apps/card-creator/url-params/parse.ts
+++ b/src/apps/card-creator/url-params/parse.ts
@@ -1,0 +1,281 @@
+/**
+ * Turns the query of a prefill link into a single patch for loadCard, plus
+ * the list of params that could not be applied.
+ *
+ * Pure and browser-free on purpose, so the whole vocabulary is testable
+ * without a DOM. The two steps that need a browser (serialising the card text
+ * to HTML, and fetching the artwork) happen in index.ts, after this.
+ */
+
+import {
+	getCardBacksForTypeAndStyle,
+	getSuggestedCardBack,
+} from "@fabkit/shared/config/cards/card_backs.ts";
+import {
+	type CardStyle,
+	CardStyles,
+} from "@fabkit/shared/config/cards/card_styles.ts";
+import type { CardType } from "@fabkit/shared/config/cards/types.ts";
+import type { JSONContent } from "@tiptap/core";
+import { isFieldVisible } from "../components/utils.ts";
+import type { CardCreatorCardBack } from "../config/rendering.ts";
+import type { CardCreatorState } from "../stores/card-creator.ts";
+import { getArtworkUrl } from "./artwork.ts";
+import { getCardTextDoc } from "./text.ts";
+import {
+	FieldParams,
+	getCardStyleParam,
+	getCardTypeParam,
+	type IgnoredParam,
+	PrefillParamNames,
+} from "./vocabulary.ts";
+
+/** What a link with no type or style param opens as. */
+const DefaultCardType: CardType = "action";
+const DefaultCardStyle: CardStyle = "dented";
+
+export interface PrefillParseResult {
+	/**
+	 * Everything the link sets that this module can resolve on its own. It goes
+	 * into a single loadCard call, which resets to initial state before merging,
+	 * so nothing may be applied through a second one.
+	 */
+	patch: Partial<CardCreatorState>;
+	/**
+	 * Card text as a Tiptap document. Kept out of the patch because its HTML
+	 * counterpart needs a DOM to generate. The caller adds both fields at once,
+	 * and both are required: CardTextNode alone leaves the renderers blank
+	 * until the first keystroke, since only a user edit writes CardTextHTML.
+	 */
+	textDoc: JSONContent | null;
+	/** Fetched by the caller, since loadCard cannot carry a Blob it doesn't have. */
+	artworkUrl: string | null;
+	ignored: IgnoredParam[];
+}
+
+/**
+ * Stock frames only. Custom frames are user-uploaded rows whose ids and names
+ * mean nothing on another device, so a public link resolving against one would
+ * pick up whatever the recipient happened to upload under that name. Reading
+ * the manifest directly rather than filtering getAvailableCardBacks makes that
+ * structural instead of a filter a later edit could drop.
+ */
+const getStockCardBacks = (
+	cardType: CardType,
+	style: CardStyle,
+): CardCreatorCardBack[] =>
+	getCardBacksForTypeAndStyle(cardType, style) as CardCreatorCardBack[];
+
+/**
+ * Search values reach us already parsed by the router, so a numeric-looking
+ * value arrives as a number and a JSON-looking one as an object. Everything
+ * this vocabulary accepts is expressible as a non-empty string; anything else
+ * is reported rather than coerced into "[object Object]".
+ */
+const getParamValues = (
+	search: Record<string, unknown>,
+	ignored: IgnoredParam[],
+): Map<string, string> => {
+	const values = new Map<string, string>();
+
+	for (const [param, raw] of Object.entries(search)) {
+		if (!PrefillParamNames.has(param)) {
+			ignored.push({ param, reason: "unknown_param" });
+		} else {
+			const isTextual =
+				typeof raw === "string" ||
+				typeof raw === "number" ||
+				typeof raw === "boolean";
+			const value = isTextual ? String(raw).trim() : "";
+
+			if (value === "") {
+				ignored.push({ param, reason: "invalid_value" });
+			} else {
+				values.set(param, value);
+			}
+		}
+	}
+
+	return values;
+};
+
+const getFrameByName = (
+	name: string | undefined,
+	param: string,
+	available: CardCreatorCardBack[],
+	ignored: IgnoredParam[],
+): CardCreatorCardBack | null => {
+	let frame: CardCreatorCardBack | null = null;
+
+	if (name !== undefined) {
+		const wanted = name.toLowerCase();
+		frame =
+			available.find((back) => back.name.toLowerCase() === wanted) ?? null;
+
+		if (frame === null) {
+			ignored.push({ param, reason: "unknown_frame" });
+		}
+	}
+
+	return frame;
+};
+
+interface FrameSelection {
+	style: CardStyle;
+	back: CardCreatorCardBack | null;
+	backRight: CardCreatorCardBack | null;
+	/**
+	 * Whether the link asked for a second frame at all, which is not the same
+	 * as getting one: a name that did not resolve leaves backRight null.
+	 */
+	isSecondFrameRequested: boolean;
+}
+
+/**
+ * Resolves both halves of the frame the way setCardType would, which loadCard
+ * cannot do for itself: it is a raw merge with no side effects, so without
+ * this a `type=hero` link would keep the initial state's action frame.
+ *
+ * CardBackRight stays null unless frame2 resolved. That null is the whole of
+ * what makes a card hybrid, so a link cannot express a hybrid without one.
+ */
+const getFrames = (
+	values: Map<string, string>,
+	cardType: CardType,
+	requestedStyle: CardStyle,
+	isStyleRequested: boolean,
+	ignored: IgnoredParam[],
+): FrameSelection => {
+	let style = requestedStyle;
+	let available = getStockCardBacks(cardType, style);
+
+	// Four type/style combinations have no frames at all. setCardType falls back
+	// to a style that does rather than leaving the card unrenderable, so a link
+	// asking for one of them lands where the form's own type picker would.
+	if (available.length === 0) {
+		for (const fallbackStyle of CardStyles) {
+			const fallbackAvailable = getStockCardBacks(cardType, fallbackStyle);
+
+			if (fallbackAvailable.length > 0) {
+				style = fallbackStyle;
+				available = fallbackAvailable;
+				break;
+			}
+		}
+	}
+
+	// Only worth reporting when the link asked for the style it did not get.
+	// Falling back from an unrequested default is not something the author did.
+	if (isStyleRequested && style !== requestedStyle) {
+		ignored.push({ param: "style", reason: "style_unavailable" });
+	}
+
+	const named = getFrameByName(
+		values.get("frame"),
+		"frame",
+		available,
+		ignored,
+	);
+
+	const secondFrame = values.get("frame2");
+
+	return {
+		style,
+		back:
+			named ?? (getSuggestedCardBack(available) as CardCreatorCardBack | null),
+		backRight: getFrameByName(secondFrame, "frame2", available, ignored),
+		isSecondFrameRequested: secondFrame !== undefined,
+	};
+};
+
+export const parsePrefillParams = (
+	search: Record<string, unknown>,
+): PrefillParseResult => {
+	const ignored: IgnoredParam[] = [];
+	const values = getParamValues(search, ignored);
+
+	let cardType: CardType = DefaultCardType;
+	const requestedType = values.get("type");
+	if (requestedType !== undefined) {
+		const parsed = getCardTypeParam(requestedType);
+
+		if (parsed === undefined) {
+			ignored.push({ param: "type", reason: "invalid_value" });
+		} else {
+			cardType = parsed;
+		}
+	}
+
+	let cardStyle: CardStyle = DefaultCardStyle;
+	let isStyleRequested = false;
+	const requestedStyle = values.get("style");
+	if (requestedStyle !== undefined) {
+		const parsed = getCardStyleParam(requestedStyle);
+
+		if (parsed === undefined) {
+			ignored.push({ param: "style", reason: "invalid_value" });
+		} else {
+			cardStyle = parsed;
+			isStyleRequested = true;
+		}
+	}
+
+	const frames = getFrames(
+		values,
+		cardType,
+		cardStyle,
+		isStyleRequested,
+		ignored,
+	);
+	const patch: Partial<CardCreatorState> = {
+		CardType: cardType,
+		CardBackStyle: frames.style,
+		CardBack: frames.back,
+		CardBackRight: frames.backRight,
+	};
+
+	for (const [param, field] of Object.entries(FieldParams)) {
+		const value = values.get(param);
+
+		if (value !== undefined) {
+			if (
+				field.formField !== null &&
+				!isFieldVisible(field.formField, cardType)
+			) {
+				ignored.push({ param, reason: "not_on_card_type" });
+			} else if (field.requiresSecondFrame && frames.backRight === null) {
+				// A frame2 that did not resolve has already been reported, and
+				// fixing that name is what makes these usable, so a second line
+				// about the same cause would send the author looking for a param
+				// their link already has.
+				if (!frames.isSecondFrameRequested) {
+					ignored.push({ param, reason: "needs_second_frame" });
+				}
+			} else if (!field.applyTo(patch, value)) {
+				ignored.push({ param, reason: "invalid_value" });
+			}
+		}
+	}
+
+	let textDoc: JSONContent | null = null;
+	const text = values.get("text");
+	if (text !== undefined) {
+		if (isFieldVisible("CardText", cardType)) {
+			textDoc = getCardTextDoc(text);
+		} else {
+			ignored.push({ param: "text", reason: "not_on_card_type" });
+		}
+	}
+
+	let artworkUrl: string | null = null;
+	const art = values.get("art");
+	if (art !== undefined) {
+		artworkUrl = getArtworkUrl(art);
+
+		if (artworkUrl === null) {
+			ignored.push({ param: "art", reason: "invalid_value" });
+		}
+	}
+
+	return { patch, textDoc, artworkUrl, ignored };
+};

--- a/src/apps/card-creator/url-params/text.ts
+++ b/src/apps/card-creator/url-params/text.ts
@@ -1,0 +1,133 @@
+/**
+ * Converts a prefill link's plain text into the two representations the store
+ * keeps: the Tiptap document the editor hydrates from, and the HTML the
+ * renderers put through dangerouslySetInnerHTML.
+ *
+ * A link never supplies HTML. See
+ * docs/adr/0002-prefill-link-text-is-plain-text.md for why that surface stays
+ * closed, and why the HTML is generated from the document rather than written
+ * by hand.
+ */
+
+import { getRichTextExtensions } from "@fabkit/platform/components/form/rich-text-extensions.ts";
+import { generateHTML, type JSONContent } from "@tiptap/core";
+import { EditorCustomEmojiRows } from "../config/editor.ts";
+
+/**
+ * Same shape the editor's own input rule recognises, so the shortcodes a link
+ * author writes are the ones a user gets by typing.
+ */
+const ShortcodePattern = /:([a-zA-Z0-9_+-]+):/g;
+
+/**
+ * Bold shorthand, the same pattern @tiptap/extension-bold applies as you
+ * type: its `starInputRegex` and `underscoreInputRegex`, which take the same
+ * two delimiters, require the opening one to start the line or follow a
+ * space (so an underscore inside a word is left alone), and match a run
+ * containing no further delimiter. A link author and a user at the keyboard
+ * therefore produce the same document.
+ *
+ * Two differences follow from scanning a finished string rather than matching
+ * at a caret, and neither changes what counts as bold: the trailing `$` is
+ * dropped, and so is tiptap's guard after the closing delimiter, which exists
+ * to stop a rule firing mid-keystroke and in a scan would reject the first of
+ * two bold runs on one line.
+ *
+ * The guards are lookaheads, never lookbehinds: the build targets Safari 16,
+ * which cannot parse a lookbehind, and a regex literal it cannot parse takes
+ * the whole chunk down with it rather than just this feature.
+ *
+ * This is shorthand the parser interprets, not markup it passes through. The
+ * document is still built here and the HTML still generated from it, so the
+ * rule that a link can never supply HTML is untouched.
+ */
+const BoldPattern =
+	/(^|\s)(?:\*\*(?!\s+\*\*)([^*]+)\*\*|__(?!\s+__)([^_]+)__)/g;
+
+const CardEmojis = EditorCustomEmojiRows.flat();
+
+const getEmojiName = (shortcode: string): string | undefined =>
+	CardEmojis.find(
+		(emoji) => emoji.name === shortcode || emoji.shortcodes.includes(shortcode),
+	)?.name;
+
+/**
+ * Splits a run of text into text and emoji nodes, carrying the run's marks
+ * onto the text. An unrecognised shortcode is left in the surrounding text,
+ * which is exactly what the editor does with one. Marks stay off the emoji
+ * nodes: bolding an icon means nothing, and ProseMirror is happy either way.
+ */
+const getRunContent = (run: string, isBold: boolean): JSONContent[] => {
+	const content: JSONContent[] = [];
+	let consumed = 0;
+
+	// A fresh array per node rather than one shared by the whole run:
+	// CardTextNode is held in the store, persisted to IndexedDB, and written
+	// into a .fabkit export verbatim, so nodes must not alias one mutable array.
+	const getMarks = (): JSONContent["marks"] =>
+		isBold ? [{ type: "bold" }] : undefined;
+
+	for (const match of run.matchAll(ShortcodePattern)) {
+		const name = getEmojiName(match[1]);
+
+		if (name !== undefined) {
+			const literal = run.slice(consumed, match.index);
+
+			if (literal !== "") {
+				content.push({ type: "text", text: literal, marks: getMarks() });
+			}
+			content.push({ type: "emoji", attrs: { name } });
+			consumed = match.index + match[0].length;
+		}
+	}
+
+	const remainder = run.slice(consumed);
+	if (remainder !== "") {
+		content.push({ type: "text", text: remainder, marks: getMarks() });
+	}
+
+	return content;
+};
+
+/** Splits one line into bold and unbold runs, then each run into nodes. */
+const getLineContent = (line: string): JSONContent[] => {
+	const content: JSONContent[] = [];
+	let consumed = 0;
+
+	for (const match of line.matchAll(BoldPattern)) {
+		const [matched, leading, starred, underscored] = match;
+		// Exactly one of the two delimiter alternatives captured.
+		const bolded = starred ?? underscored;
+
+		// The space the pattern needs before the opening delimiter belongs to
+		// the text in front of it, not to the bold run.
+		content.push(
+			...getRunContent(line.slice(consumed, match.index) + leading, false),
+		);
+		content.push(...getRunContent(bolded, true));
+		consumed = match.index + matched.length;
+	}
+
+	content.push(...getRunContent(line.slice(consumed), false));
+
+	return content;
+};
+
+export const getCardTextDoc = (text: string): JSONContent => ({
+	type: "doc",
+	content: text.split(/\r?\n/).map((line) => {
+		const content = getLineContent(line);
+		// A paragraph with an empty content array is not a valid document node,
+		// so a blank line is a paragraph with no content property at all.
+		return content.length > 0
+			? { type: "paragraph", content }
+			: { type: "paragraph" };
+	}),
+});
+
+/**
+ * Needs a DOM (ProseMirror serialises through the global document), so this
+ * belongs to the browser-side apply step, not to parse.ts.
+ */
+export const getCardTextHTML = (doc: JSONContent): string =>
+	generateHTML(doc, getRichTextExtensions(CardEmojis));

--- a/src/apps/card-creator/url-params/vocabulary.ts
+++ b/src/apps/card-creator/url-params/vocabulary.ts
@@ -1,0 +1,184 @@
+/**
+ * The public vocabulary of a prefill link: every param an external app may
+ * put in a /card-creator URL, and how each one turns into store state.
+ *
+ * This vocabulary is a published interface and is append-only: a param is
+ * never renamed or removed, which is why there is no version param (see
+ * docs/adr/0001-prefill-links-use-readable-params.md). It lives in the
+ * card-creator app rather than shared/ because it describes this app's
+ * surface, not FAB domain data.
+ */
+
+import {
+	type CardStyle,
+	CardStyles,
+} from "@fabkit/shared/config/cards/card_styles.ts";
+import { CardClasses } from "@fabkit/shared/config/cards/classes.ts";
+import {
+	type CardFormField,
+	CardFormFields,
+} from "@fabkit/shared/config/cards/form_fields.ts";
+import { CardRarities } from "@fabkit/shared/config/cards/rarities.ts";
+import { CardTalents } from "@fabkit/shared/config/cards/talents.ts";
+import { type CardType, CardTypes } from "@fabkit/shared/config/cards/types.ts";
+import {
+	type CardCreatorState,
+	HYBRID_SPLIT_MAX,
+	HYBRID_SPLIT_MIN,
+} from "../stores/card-creator.ts";
+
+/** Why a param in the link did not end up on the card. */
+export type IgnoreReason =
+	/** Not a param name in this vocabulary. */
+	| "unknown_param"
+	/** Name is known, value is not one this param accepts. */
+	| "invalid_value"
+	/** Known param for a field the chosen card type does not show. */
+	| "not_on_card_type"
+	/** split/blend with no frame2, so nothing they could change is rendered. */
+	| "needs_second_frame"
+	/** Frame name matches no stock frame for the chosen type and style. */
+	| "unknown_frame"
+	/** The chosen card type has no frames in the requested style. */
+	| "style_unavailable"
+	/** Artwork URL could not be fetched (CORS, 404, oversize, timeout). */
+	| "artwork_unavailable";
+
+export interface IgnoredParam {
+	param: string;
+	reason: IgnoreReason;
+}
+
+const getFormField = (field: keyof CardCreatorState): CardFormField | null =>
+	(CardFormFields as readonly string[]).includes(field)
+		? (field as CardFormField)
+		: null;
+
+export interface FieldParam {
+	/**
+	 * The form field whose visibility gates this param, so a link can't set a
+	 * value the chosen card type has no place to show. Null for fields every
+	 * type shows (artwork credits, set number).
+	 */
+	formField: CardFormField | null;
+	/** Only meaningful on a hybrid card, so pointless without frame2. */
+	requiresSecondFrame: boolean;
+	/** Writes the value onto the patch; false means the value was unusable. */
+	applyTo: (patch: Partial<CardCreatorState>, value: string) => boolean;
+}
+
+const defineFieldParam = <K extends keyof CardCreatorState>(
+	field: K,
+	parse: (value: string) => CardCreatorState[K] | undefined,
+	{ requiresSecondFrame = false, formField = getFormField(field) } = {},
+): FieldParam => ({
+	formField,
+	requiresSecondFrame,
+	applyTo: (patch, value) => {
+		const parsed = parse(value);
+		const isUsable = parsed !== undefined;
+		if (isUsable) {
+			patch[field] = parsed;
+		}
+		return isUsable;
+	},
+});
+
+/** Values arrive trimmed and non-empty, so any string is a usable free text. */
+const getFreeText = (value: string): string => value;
+
+const getEnumKey =
+	<T extends string>(keys: Record<T, unknown>) =>
+	(value: string): T | undefined => {
+		const key = value.toLowerCase();
+		return Object.hasOwn(keys, key) ? (key as T) : undefined;
+	};
+
+const getPitch = (value: string): 1 | 2 | 3 | undefined => {
+	const pitches = [1, 2, 3] as const;
+	return pitches.find((pitch) => String(pitch) === value);
+};
+
+const getWeaponHands = (value: string): "(1H)" | "(2H)" | undefined => {
+	const hands = { "1h": "(1H)", "2h": "(2H)" } as const;
+	return hands[value.toLowerCase() as keyof typeof hands];
+};
+
+/**
+ * The store holds the seam position and softness as 0..1, but a link author
+ * writing "split=0.5" versus "split=50" will guess wrong, so the public unit
+ * is a percentage. Out of range is rejected rather than clamped, matching how
+ * an out-of-range pitch is treated.
+ */
+const getPercentageFraction =
+	(minPercent: number, maxPercent: number) =>
+	(value: string): number | undefined => {
+		const percent = Number(value);
+		const isInRange =
+			Number.isInteger(percent) &&
+			percent >= minPercent &&
+			percent <= maxPercent;
+		return isInRange ? percent / 100 : undefined;
+	};
+
+export const FieldParams: Record<string, FieldParam> = {
+	name: defineFieldParam("CardName", getFreeText),
+	pitch: defineFieldParam("CardPitch", getPitch),
+	cost: defineFieldParam("CardResource", getFreeText),
+	power: defineFieldParam("CardPower", getFreeText),
+	defense: defineFieldParam("CardDefense", getFreeText),
+	life: defineFieldParam("CardLife", getFreeText),
+	intellect: defineFieldParam("CardHeroIntellect", getFreeText),
+	class: defineFieldParam("CardClass", getEnumKey(CardClasses)),
+	class2: defineFieldParam("CardSecondaryClass", getEnumKey(CardClasses)),
+	talent: defineFieldParam("CardTalent", getEnumKey(CardTalents)),
+	subtype: defineFieldParam("CardSubType", getFreeText),
+	rarity: defineFieldParam("CardRarity", getEnumKey(CardRarities)),
+	weapon: defineFieldParam("CardWeapon", getWeaponHands),
+	group: defineFieldParam("CardMacroGroup", getFreeText),
+	artist: defineFieldParam("CardArtworkCredits", getFreeText),
+	setnumber: defineFieldParam("CardSetNumber", (value) => value.toUpperCase()),
+	split: defineFieldParam(
+		"CardBackSplit",
+		getPercentageFraction(HYBRID_SPLIT_MIN * 100, HYBRID_SPLIT_MAX * 100),
+		{ requiresSecondFrame: true },
+	),
+	blend: defineFieldParam("CardBackBlend", getPercentageFraction(0, 100), {
+		requiresSecondFrame: true,
+	}),
+};
+
+/**
+ * Meld is the one card type a link cannot ask for: its state nests two
+ * independently composed halves, which a flat param vocabulary has no way to
+ * express.
+ */
+export const getCardTypeParam = (value: string): CardType | undefined => {
+	const key = value.toLowerCase();
+	const isAddressable = Object.hasOwn(CardTypes, key) && key !== "meld";
+	return isAddressable ? (key as CardType) : undefined;
+};
+
+export const getCardStyleParam = (value: string): CardStyle | undefined =>
+	CardStyles.find((style) => style === value.toLowerCase());
+
+/**
+ * Params parsed by parse.ts itself rather than through FieldParams, because
+ * they don't map one-to-one onto a store field: type and style decide which
+ * frames exist, frame/frame2 resolve against that list, text becomes two
+ * fields, and art is fetched in the browser after the patch is applied.
+ */
+const StructuralParamNames = [
+	"type",
+	"style",
+	"frame",
+	"frame2",
+	"text",
+	"art",
+] as const;
+
+/** Every name this vocabulary recognises. Anything else is reported back. */
+export const PrefillParamNames: ReadonlySet<string> = new Set([
+	...Object.keys(FieldParams),
+	...StructuralParamNames,
+]);

--- a/src/platform/components/form/RichTextEditor.tsx
+++ b/src/platform/components/form/RichTextEditor.tsx
@@ -1,14 +1,9 @@
-import Bold from "@tiptap/extension-bold";
-import { BulletList, ListItem, OrderedList } from "@tiptap/extension-list";
-import TextAlign from "@tiptap/extension-text-align";
-import Underline from "@tiptap/extension-underline";
 import {
 	type Content,
 	EditorContent,
 	useEditor,
 	useEditorState,
 } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
 import {
 	AlignCenter as AlignCenterIcon,
 	AlignLeft as AlignLeftIcon,
@@ -20,8 +15,8 @@ import {
 	Underline as UnderlineIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Emoji, type EmojiItem } from "./extensions/Emoji.ts";
-import { FabDash } from "./extensions/FabDash.ts";
+import type { EmojiItem } from "./extensions/Emoji.ts";
+import { getRichTextExtensions } from "./rich-text-extensions.ts";
 import "../../../styles/components/rich-text-editor.css";
 
 export type { EmojiItem };
@@ -41,37 +36,7 @@ export default function RichTextEditor({
 	const customEmojisRow1 = customEmojis[0] ?? [];
 	const customEmojisRow2 = customEmojis[1] ?? [];
 	const editor = useEditor({
-		extensions: [
-			StarterKit.configure({
-				bold: false,
-				listItem: false,
-				orderedList: false,
-				bulletList: false,
-			}),
-			Bold,
-			Underline,
-			ListItem,
-			BulletList.configure({
-				HTMLAttributes: {
-					class: "list-disc ml-2",
-				},
-			}),
-			OrderedList.configure({
-				HTMLAttributes: {
-					class: "list-decimal ml-2",
-				},
-			}),
-			TextAlign.configure({
-				types: ["heading", "paragraph"],
-			}),
-			Emoji.configure({
-				HTMLAttributes: {
-					class: "fab-icon",
-				},
-				emojis: customEmojis.flat(),
-			}),
-			FabDash,
-		],
+		extensions: getRichTextExtensions(customEmojis.flat()),
 		content: content,
 		onUpdate: ({ editor }) => {
 			if (onChange) {

--- a/src/platform/components/form/rich-text-extensions.ts
+++ b/src/platform/components/form/rich-text-extensions.ts
@@ -1,0 +1,48 @@
+import Bold from "@tiptap/extension-bold";
+import { BulletList, ListItem, OrderedList } from "@tiptap/extension-list";
+import TextAlign from "@tiptap/extension-text-align";
+import Underline from "@tiptap/extension-underline";
+import type { Extensions } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { Emoji, type EmojiItem } from "./extensions/Emoji.ts";
+import { FabDash } from "./extensions/FabDash.ts";
+
+/**
+ * The editor's extension set, shared with anything that has to produce the
+ * same HTML without an editor instance (generateHTML from @tiptap/core takes
+ * this array). Keeping it in one place is what makes generated HTML and
+ * editor-typed HTML the same string for the same document.
+ */
+export const getRichTextExtensions = (
+	customEmojis: EmojiItem[],
+): Extensions => [
+	StarterKit.configure({
+		bold: false,
+		listItem: false,
+		orderedList: false,
+		bulletList: false,
+	}),
+	Bold,
+	Underline,
+	ListItem,
+	BulletList.configure({
+		HTMLAttributes: {
+			class: "list-disc ml-2",
+		},
+	}),
+	OrderedList.configure({
+		HTMLAttributes: {
+			class: "list-decimal ml-2",
+		},
+	}),
+	TextAlign.configure({
+		types: ["heading", "paragraph"],
+	}),
+	Emoji.configure({
+		HTMLAttributes: {
+			class: "fab-icon",
+		},
+		emojis: customEmojis,
+	}),
+	FabDash,
+];

--- a/src/routes/card-creator.tsx
+++ b/src/routes/card-creator.tsx
@@ -26,28 +26,50 @@ import { HybridCardBackField } from "@fabkit/apps/card-creator/components/card-c
 import { MeldHalfFields } from "@fabkit/apps/card-creator/components/card-creator/fields/MeldHalfFields.tsx";
 import { ResetButton } from "@fabkit/apps/card-creator/components/card-creator/fields/ResetButton.tsx";
 import { SaveButton } from "@fabkit/apps/card-creator/components/card-creator/fields/SaveButton.tsx";
+import { PrefillNotice } from "@fabkit/apps/card-creator/components/card-creator/PrefillNotice.tsx";
 import { Renderer } from "@fabkit/apps/card-creator/components/card-creator/Renderer.tsx";
 import { AllRenderConfigVariations } from "@fabkit/apps/card-creator/config/rendering.ts";
 import { useCardCreator } from "@fabkit/apps/card-creator/stores/card-creator.ts";
 import { ensureCustomFramesLoaded } from "@fabkit/apps/card-creator/stores/custom-frames.ts";
+import {
+	applyPrefillParams,
+	dismissStalePrefillNotice,
+} from "@fabkit/apps/card-creator/url-params";
 import {
 	Dialog,
 	DialogBackdrop,
 	DialogPanel,
 	DialogTitle,
 } from "@headlessui/react";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { Settings } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/card-creator")({
 	component: RouteComponent,
+	// A prefill link's params are whatever an external app put in the URL, so
+	// nothing is rejected here. Parsing and reporting is applyPrefillParams's
+	// job, and it needs to see the params it can't use in order to say so.
+	validateSearch: (search: Record<string, unknown>) => search,
+	loaderDeps: ({ search }) => search,
 	// The renderer can already have a custom-frame CardBack in the store
 	// (loaded from gallery/session) by the time this route mounts — the
 	// registry must be hydrated before that first render, not after.
-	loader: async () => {
+	loader: async ({ deps, abortController }) => {
 		await ensureCustomFramesLoaded();
+
+		// Applying here rather than in an effect means the card is complete on
+		// first paint, with no flash of an empty form. Stripping the params
+		// afterwards is what keeps it one-shot: this loader runs again on every
+		// invalidation, and params still in the URL would be re-applied over
+		// whatever the user had changed since.
+		if (Object.keys(deps).length > 0) {
+			await applyPrefillParams(deps, abortController.signal);
+			throw redirect({ to: "/card-creator", search: {}, replace: true });
+		} else {
+			dismissStalePrefillNotice();
+		}
 	},
 });
 
@@ -69,6 +91,8 @@ function RouteComponent() {
 		// elsewhere on the site: the card preview is 628px tall and has to stay
 		// fully visible on a 1080p display without scrolling.
 		<div className="flex flex-1 flex-col w-full px-4 sm:px-6 lg:px-8 pb-4 sm:pb-6 lg:pb-8 gap-4 lg:gap-3 pt-6 sm:pt-8 lg:pt-6">
+			<PrefillNotice />
+
 			{/* Card type selector — full width, above the rest.
 				On meld + <lg, sticks below the mobile top bar so it stays visible
 				with the preview while the form scrolls. */}

--- a/tests/prefill-links.test.ts
+++ b/tests/prefill-links.test.ts
@@ -1,0 +1,664 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { isFieldVisible } from "../src/apps/card-creator/components/utils.ts";
+import { addFrameImageAndMirrors } from "../src/apps/card-creator/persistence/custom-frames-storage.ts";
+import { db } from "../src/apps/card-creator/persistence/db.ts";
+import {
+	HYBRID_BLEND_DEFAULT,
+	HYBRID_SPLIT_DEFAULT,
+	useCardCreator,
+} from "../src/apps/card-creator/stores/card-creator.ts";
+import {
+	getCustomFramesSnapshot,
+	reloadCustomFrames,
+} from "../src/apps/card-creator/stores/custom-frames.ts";
+import { getArtworkUrl } from "../src/apps/card-creator/url-params/artwork.ts";
+import { applyPrefillParams } from "../src/apps/card-creator/url-params/index.ts";
+import {
+	dismissPrefillNotice,
+	dismissStalePrefillNotice,
+	getPrefillNotice,
+	setPrefillNotice,
+} from "../src/apps/card-creator/url-params/notice.ts";
+import { parsePrefillParams } from "../src/apps/card-creator/url-params/parse.ts";
+import { getCardTextDoc } from "../src/apps/card-creator/url-params/text.ts";
+import {
+	FieldParams,
+	type IgnoredParam,
+} from "../src/apps/card-creator/url-params/vocabulary.ts";
+import { CardStyles } from "../src/shared/config/cards/card_styles.ts";
+import { type CardType, CardTypes } from "../src/shared/config/cards/types.ts";
+
+const signal = (): AbortSignal => new AbortController().signal;
+
+const reasonFor = (
+	ignored: IgnoredParam[],
+	param: string,
+): string | undefined => ignored.find((entry) => entry.param === param)?.reason;
+
+const addressableTypes = Object.keys(CardTypes).filter(
+	(type) => type !== "meld",
+) as CardType[];
+
+async function clearCustomFrames(): Promise<void> {
+	await db.transaction("rw", db.customFrames, db.frameImages, async () => {
+		await db.customFrames.clear();
+		await db.frameImages.clear();
+	});
+	await reloadCustomFrames();
+}
+
+beforeEach(async () => {
+	await clearCustomFrames();
+});
+
+// ─── Field params ────────────────────────────────────────────────────────────
+
+describe("field params", () => {
+	it("maps every param an action card shows onto its store key", () => {
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			name: "Sink Below",
+			pitch: "3",
+			cost: "0",
+			power: "4",
+			defense: "3",
+			life: "2",
+			class: "ninja",
+			class2: "assassin",
+			talent: "shadow",
+			subtype: "attack",
+			rarity: "majestic",
+			artist: "A. Painter",
+			setnumber: "wtr001",
+		});
+
+		expect(ignored).toEqual([]);
+		expect(patch.CardType).toBe("action");
+		expect(patch.CardName).toBe("Sink Below");
+		expect(patch.CardPitch).toBe(3);
+		expect(patch.CardResource).toBe("0");
+		expect(patch.CardPower).toBe("4");
+		expect(patch.CardDefense).toBe("3");
+		expect(patch.CardLife).toBe("2");
+		expect(patch.CardClass).toBe("ninja");
+		expect(patch.CardSecondaryClass).toBe("assassin");
+		expect(patch.CardTalent).toBe("shadow");
+		expect(patch.CardSubType).toBe("attack");
+		expect(patch.CardRarity).toBe("majestic");
+		expect(patch.CardArtworkCredits).toBe("A. Painter");
+		// setCardSetNumber uppercases, and loadCard runs no setters, so the
+		// parser has to do it instead.
+		expect(patch.CardSetNumber).toBe("WTR001");
+	});
+
+	it("maps the params only some card types show", () => {
+		expect(
+			parsePrefillParams({ type: "hero", intellect: "4" }).patch
+				.CardHeroIntellect,
+		).toBe("4");
+		expect(
+			parsePrefillParams({ type: "weapon", weapon: "2h" }).patch.CardWeapon,
+		).toBe("(2H)");
+		expect(
+			parsePrefillParams({ type: "macro", group: "Arcane Barrier" }).patch
+				.CardMacroGroup,
+		).toBe("Arcane Barrier");
+	});
+
+	it("reports an unknown param name and applies the rest", () => {
+		const { patch, ignored } = parsePrefillParams({
+			name: "Snatch",
+			colour: "red",
+		});
+
+		expect(reasonFor(ignored, "colour")).toBe("unknown_param");
+		expect(patch.CardName).toBe("Snatch");
+	});
+
+	it("reports an unusable value and applies the rest", () => {
+		const { patch, ignored } = parsePrefillParams({
+			name: "Snatch",
+			class: "ninjas",
+			pitch: "7",
+			rarity: "ultra",
+			weapon: "3h",
+			name2: "",
+		});
+
+		expect(reasonFor(ignored, "class")).toBe("invalid_value");
+		expect(reasonFor(ignored, "pitch")).toBe("invalid_value");
+		expect(reasonFor(ignored, "rarity")).toBe("invalid_value");
+		expect(patch.CardClass).toBeUndefined();
+		expect(patch.CardPitch).toBeUndefined();
+		expect(patch.CardName).toBe("Snatch");
+	});
+
+	it("reports a blank value rather than writing it", () => {
+		const { patch, ignored } = parsePrefillParams({ name: "   " });
+
+		expect(reasonFor(ignored, "name")).toBe("invalid_value");
+		expect(patch.CardName).toBeUndefined();
+	});
+
+	it("reports a param the chosen card type has no field for", () => {
+		const { patch, ignored } = parsePrefillParams({
+			type: "hero",
+			pitch: "1",
+			defense: "3",
+			life: "20",
+		});
+
+		expect(isFieldVisible("CardPitch", "hero")).toBe(false);
+		expect(reasonFor(ignored, "pitch")).toBe("not_on_card_type");
+		expect(reasonFor(ignored, "defense")).toBe("not_on_card_type");
+		expect(patch.CardPitch).toBeUndefined();
+		expect(patch.CardLife).toBe("20");
+	});
+
+	it("gates every field param on a form field the card type actually shows", () => {
+		// Guards the whole vocabulary rather than one param: anything a card type
+		// has no field for must be reported, never silently written.
+		for (const type of addressableTypes) {
+			for (const [param, field] of Object.entries(FieldParams)) {
+				const isHidden =
+					field.formField !== null && !isFieldVisible(field.formField, type);
+
+				if (isHidden) {
+					const { ignored } = parsePrefillParams({ type, [param]: "1" });
+
+					expect({ type, param, reason: reasonFor(ignored, param) }).toEqual({
+						type,
+						param,
+						reason: "not_on_card_type",
+					});
+				}
+			}
+		}
+	});
+});
+
+// ─── Card type ───────────────────────────────────────────────────────────────
+
+describe("card type", () => {
+	it("falls back to the default type when none is given", () => {
+		expect(parsePrefillParams({}).patch.CardType).toBe("action");
+	});
+
+	it("rejects meld and says so", () => {
+		const { patch, ignored } = parsePrefillParams({ type: "meld" });
+
+		expect(reasonFor(ignored, "type")).toBe("invalid_value");
+		expect(patch.CardType).toBe("action");
+	});
+
+	it("accepts a type case-insensitively", () => {
+		expect(
+			parsePrefillParams({ type: "Weapon_Equipment" }).patch.CardType,
+		).toBe("weapon_equipment");
+	});
+});
+
+// ─── Frames ──────────────────────────────────────────────────────────────────
+
+describe("frames", () => {
+	it("resolves the same frame and style setCardType would, for every type and style", () => {
+		for (const type of addressableTypes) {
+			for (const style of CardStyles) {
+				useCardCreator.getState().reset();
+				useCardCreator.getState().setCardBackStyle(style);
+				useCardCreator.getState().setCardType(type);
+				const fromStore = useCardCreator.getState();
+				const { patch } = parsePrefillParams({ type, style });
+
+				expect({
+					type,
+					style,
+					back: patch.CardBack?.id ?? null,
+					backStyle: patch.CardBackStyle,
+				}).toEqual({
+					type,
+					style,
+					back: fromStore.CardBack?.id ?? null,
+					backStyle: fromStore.CardBackStyle,
+				});
+			}
+		}
+	});
+
+	it("falls back to a style that has frames, and says so", () => {
+		// weapon has no flat frames, so asking for flat lands on dented, exactly
+		// as picking weapon in the form does.
+		const { patch, ignored } = parsePrefillParams({
+			type: "weapon",
+			style: "flat",
+		});
+
+		expect(patch.CardBackStyle).toBe("dented");
+		expect(patch.CardBack?.name).toBe("Weapon");
+		expect(reasonFor(ignored, "style")).toBe("style_unavailable");
+	});
+
+	it("says nothing about a style the link never asked for", () => {
+		const { ignored } = parsePrefillParams({ type: "weapon" });
+
+		expect(reasonFor(ignored, "style")).toBeUndefined();
+	});
+
+	it("leaves the frame unset for a type with no frames at all", () => {
+		const { patch } = parsePrefillParams({ type: "event" });
+
+		expect(patch.CardBack).toBeNull();
+	});
+
+	it("matches a frame name case-insensitively, within the chosen type", () => {
+		// Aria is both a general frame and a hero frame, so the name alone does
+		// not identify one; type and style are what make it resolve.
+		const asAction = parsePrefillParams({ type: "action", frame: "aRiA" });
+		const asHero = parsePrefillParams({ type: "hero", frame: "aria" });
+
+		expect(asAction.patch.CardBack?.type).toBe("general");
+		expect(asHero.patch.CardBack?.type).toBe("hero");
+		expect(asAction.patch.CardBack?.id).not.toBe(
+			asHero.patch.CardBack?.id as number,
+		);
+	});
+
+	it("reports an unresolvable frame name and falls back to the suggested frame", () => {
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			frame: "Nonesuch",
+		});
+
+		expect(reasonFor(ignored, "frame")).toBe("unknown_frame");
+		expect(patch.CardBack?.name).toBe("Aria");
+	});
+
+	it("never resolves a name that only a custom frame has", async () => {
+		// A custom frame is a local IndexedDB row; resolving a public link against
+		// one would pick up whatever the recipient uploaded under that name.
+		await addFrameImageAndMirrors(
+			{
+				payloadHash: "prefill-hash",
+				sourceHash: "prefill-src",
+				normVersion: 1,
+				image: new Blob([new Uint8Array(10)], { type: "image/webp" }),
+				preview: new Blob([new Uint8Array(2)], { type: "image/webp" }),
+				byteSize: 10,
+			},
+			[
+				{
+					name: "Smuggler",
+					type: "general",
+					dented: true,
+					renderer: "normal_dented",
+					mirrorsCardBackId: 1,
+				},
+			],
+		);
+		await reloadCustomFrames();
+
+		expect(
+			getCustomFramesSnapshot().some((frame) => frame.name === "Smuggler"),
+		).toBe(true);
+
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			frame: "Smuggler",
+		});
+
+		expect(reasonFor(ignored, "frame")).toBe("unknown_frame");
+		expect(patch.CardBack?.source).toBeUndefined();
+	});
+});
+
+// ─── Hybrid ──────────────────────────────────────────────────────────────────
+
+describe("hybrid", () => {
+	it("leaves the right frame null without frame2, which is what makes a card non-hybrid", () => {
+		expect(
+			parsePrefillParams({ type: "action" }).patch.CardBackRight,
+		).toBeNull();
+	});
+
+	it("makes the card hybrid on frame2 alone", () => {
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			frame2: "Aria",
+		});
+
+		expect(ignored).toEqual([]);
+		expect(patch.CardBackRight?.name).toBe("Aria");
+		expect(patch.CardBack?.name).toBe("Aria");
+	});
+
+	it("converts split and blend from percent to the stored fraction", () => {
+		const { patch } = parsePrefillParams({
+			type: "action",
+			frame2: "Aria",
+			split: "25",
+			blend: "60",
+		});
+
+		expect(patch.CardBackSplit).toBe(0.25);
+		expect(patch.CardBackBlend).toBe(0.6);
+	});
+
+	it("does not magnetise a near-centre split to dead centre", () => {
+		// setCardBackSplit snaps, which exists to make dragging land on 50. A link
+		// author writing 49 means 49.
+		const { patch } = parsePrefillParams({
+			type: "action",
+			frame2: "Aria",
+			split: "49",
+		});
+
+		expect(patch.CardBackSplit).toBe(0.49);
+	});
+
+	it("reports an out-of-range split or blend rather than clamping it", () => {
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			frame2: "Aria",
+			split: "150",
+			blend: "-1",
+		});
+
+		expect(reasonFor(ignored, "split")).toBe("invalid_value");
+		expect(reasonFor(ignored, "blend")).toBe("invalid_value");
+		expect(patch.CardBackSplit).toBeUndefined();
+		expect(patch.CardBackBlend).toBeUndefined();
+	});
+
+	it("blames only frame2 when the second frame name did not resolve", () => {
+		// Two lines for one cause would send the author looking for a frame2
+		// their link already has. Fixing the name is what makes split usable.
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			frame2: "Nonesuch",
+			split: "40",
+		});
+
+		expect(reasonFor(ignored, "frame2")).toBe("unknown_frame");
+		expect(reasonFor(ignored, "split")).toBeUndefined();
+		expect(patch.CardBackSplit).toBeUndefined();
+	});
+
+	it("reports split and blend on a card with no second frame", () => {
+		const { patch, ignored } = parsePrefillParams({
+			type: "action",
+			split: "40",
+			blend: "60",
+		});
+
+		expect(reasonFor(ignored, "split")).toBe("needs_second_frame");
+		expect(reasonFor(ignored, "blend")).toBe("needs_second_frame");
+		expect(patch.CardBackSplit).toBeUndefined();
+		expect(patch.CardBackBlend).toBeUndefined();
+	});
+
+	it("leaves the store's own defaults in place when it ignores them", () => {
+		const { patch } = parsePrefillParams({ type: "action", split: "40" });
+		const state = { ...useCardCreator.getInitialState(), ...patch };
+
+		expect(state.CardBackSplit).toBe(HYBRID_SPLIT_DEFAULT);
+		expect(state.CardBackBlend).toBe(HYBRID_BLEND_DEFAULT);
+	});
+});
+
+// ─── Card text ───────────────────────────────────────────────────────────────
+
+describe("card text", () => {
+	it("turns newlines into paragraphs", () => {
+		expect(getCardTextDoc("Go again\n\nBanish it")).toEqual({
+			type: "doc",
+			content: [
+				{ type: "paragraph", content: [{ type: "text", text: "Go again" }] },
+				{ type: "paragraph" },
+				{ type: "paragraph", content: [{ type: "text", text: "Banish it" }] },
+			],
+		});
+	});
+
+	it("turns a known shortcode into an emoji node", () => {
+		expect(getCardTextDoc("Gain 1 :cost:.")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "Gain 1 " },
+						{ type: "emoji", attrs: { name: "cost" } },
+						{ type: "text", text: "." },
+					],
+				},
+			],
+		});
+	});
+
+	it("leaves an unknown shortcode as literal text", () => {
+		expect(getCardTextDoc(":sword:")).toEqual({
+			type: "doc",
+			content: [
+				{ type: "paragraph", content: [{ type: "text", text: ":sword:" }] },
+			],
+		});
+	});
+
+	it("turns the editor's own bold shorthand into a bold mark", () => {
+		expect(getCardTextDoc("This gets **go again**.")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "This gets ", marks: undefined },
+						{ type: "text", text: "go again", marks: [{ type: "bold" }] },
+						{ type: "text", text: ".", marks: undefined },
+					],
+				},
+			],
+		});
+	});
+
+	it("accepts both bold delimiters", () => {
+		const stars = getCardTextDoc("**Phantasm**");
+		const underscores = getCardTextDoc("__Phantasm__");
+
+		expect(underscores).toEqual(stars);
+	});
+
+	it("bolds around a shortcode inside the run", () => {
+		expect(getCardTextDoc("**Gain :cost:**")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "Gain ", marks: [{ type: "bold" }] },
+						{ type: "emoji", attrs: { name: "cost" } },
+					],
+				},
+			],
+		});
+	});
+
+	it("bolds each run when a line has more than one", () => {
+		expect(getCardTextDoc("**Go again** then **Phantasm**")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "Go again", marks: [{ type: "bold" }] },
+						{ type: "text", text: " then ", marks: undefined },
+						{ type: "text", text: "Phantasm", marks: [{ type: "bold" }] },
+					],
+				},
+			],
+		});
+	});
+
+	it("takes a trailing space inside the run, as typing does", () => {
+		// @tiptap/extension-bold guards only the opening delimiter against
+		// whitespace, so this is bold in the editor and has to be bold here too.
+		expect(getCardTextDoc("**go again **")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "go again ", marks: [{ type: "bold" }] },
+					],
+				},
+			],
+		});
+	});
+
+	it("gives every node in a bold run its own marks array", () => {
+		// The document is persisted and exported verbatim, so shared arrays
+		// would let one node's marks be mutated through another.
+		const paragraph = getCardTextDoc("**a :cost: b**").content?.[0];
+		const [first, , second] = paragraph?.content ?? [];
+
+		expect(first?.marks).toEqual([{ type: "bold" }]);
+		expect(second?.marks).toEqual([{ type: "bold" }]);
+		expect(first?.marks).not.toBe(second?.marks);
+	});
+
+	it("leaves an unpaired delimiter literal", () => {
+		expect(getCardTextDoc("Gain 2* resources **unclosed")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{
+							type: "text",
+							text: "Gain 2* resources **unclosed",
+							marks: undefined,
+						},
+					],
+				},
+			],
+		});
+	});
+
+	it("leaves an underscore inside a word alone", () => {
+		// The delimiter has to follow a space or start the line, same as the
+		// editor's input rule, so a snake_case word is not formatting.
+		expect(getCardTextDoc("snake__case__here")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "snake__case__here", marks: undefined },
+					],
+				},
+			],
+		});
+	});
+
+	it("keeps markup as visible characters", () => {
+		// A link never supplies HTML: CardTextHTML reaches dangerouslySetInnerHTML,
+		// so the only text that gets there is text this converter produced.
+		expect(getCardTextDoc("<script>alert(1)</script>")).toEqual({
+			type: "doc",
+			content: [
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "<script>alert(1)</script>" }],
+				},
+			],
+		});
+	});
+
+	it("puts the parsed document on the result", () => {
+		const { textDoc } = parsePrefillParams({ text: "Go again" });
+
+		expect(textDoc).toEqual(getCardTextDoc("Go again"));
+	});
+});
+
+// ─── Artwork ─────────────────────────────────────────────────────────────────
+
+describe("artwork", () => {
+	it("accepts an https URL", () => {
+		expect(getArtworkUrl("https://example.com/art.png")).toBe(
+			"https://example.com/art.png",
+		);
+	});
+
+	it("rejects anything that is not https", () => {
+		expect(getArtworkUrl("http://example.com/art.png")).toBeNull();
+		expect(getArtworkUrl("javascript:alert(1)")).toBeNull();
+		expect(getArtworkUrl("data:image/png;base64,AAAA")).toBeNull();
+		expect(getArtworkUrl("example.com/art.png")).toBeNull();
+	});
+
+	it("reports an unusable artwork URL", () => {
+		const { artworkUrl, ignored } = parsePrefillParams({
+			art: "http://example.com/art.png",
+		});
+
+		expect(artworkUrl).toBeNull();
+		expect(reasonFor(ignored, "art")).toBe("invalid_value");
+	});
+});
+
+// ─── Notice lifetime ─────────────────────────────────────────────────────────
+
+describe("notice", () => {
+	beforeEach(() => {
+		dismissPrefillNotice();
+	});
+
+	it("survives the navigation that strips the params", () => {
+		setPrefillNotice([{ param: "colour", reason: "unknown_param" }]);
+		// The strip redirect re-enters the route with no params; the notice it
+		// just recorded has not been seen yet.
+		dismissStalePrefillNotice();
+
+		expect(getPrefillNotice()).toHaveLength(1);
+	});
+
+	it("goes when the route is entered again without a link", () => {
+		setPrefillNotice([{ param: "colour", reason: "unknown_param" }]);
+		dismissStalePrefillNotice();
+		dismissStalePrefillNotice();
+
+		expect(getPrefillNotice()).toEqual([]);
+	});
+});
+
+// ─── Applying ────────────────────────────────────────────────────────────────
+
+describe("applying a link", () => {
+	afterAll(() => {
+		useCardCreator.getState().reset();
+		dismissPrefillNotice();
+	});
+
+	it("gives the card an identity of its own", async () => {
+		// SaveButton looks the open card up by __version and updates the row it
+		// finds. Inheriting the initial state's id would make saving a prefilled
+		// card overwrite whatever was saved earlier in the same page load.
+		const before = useCardCreator.getState().__version;
+		await applyPrefillParams({ type: "action", name: "First" }, signal());
+		const first = useCardCreator.getState().__version;
+		await applyPrefillParams({ type: "action", name: "Second" }, signal());
+		const second = useCardCreator.getState().__version;
+
+		expect(first).not.toBe(before);
+		expect(second).not.toBe(first);
+	});
+
+	it("applies the patch and publishes the notice", async () => {
+		await applyPrefillParams({ name: "Sink Below", colour: "red" }, signal());
+
+		expect(useCardCreator.getState().CardName).toBe("Sink Below");
+		expect(getPrefillNotice()).toEqual([
+			{ param: "colour", reason: "unknown_param" },
+		]);
+	});
+});


### PR DESCRIPTION
# Card creator prefill links

External apps build a URL that opens the card creator with fields already filled in.

Example: `https://fabkit.io/#/card-creator?type=action&name=Sink+Below&pitch=3&cost=0&defense=3&class=ninja&text=%3Adefense%3A+Instant`

Hybrid frame: `https://fabkit.io/#/card-creator?type=action&frame=aria&frame2=assassin&split=40&blend=60`

## Settled decisions

- **Readable params, not an opaque payload.** Third parties build links from a doc, with no dependency on FABKIT internals. Exact-fidelity card sharing stays the job of `.fabkit` export.
- **Existing `/card-creator` route.** Its `loader` already awaits `ensureCustomFramesLoaded()`, which is where the hydrate belongs. Hash routing means the query lives *inside* the hash (`#/card-creator?...`), never before it.
- **Public vocabulary mapped to store keys**, not the store keys themselves. Append-only: never rename or remove a param, no `v=` param.
- **One-shot hydrate.** Params are read once on route entry; edits afterwards never write back to the URL.
- **Params stripped after apply** via a `replace` navigation. That is what keeps the hydrate one-shot: the loader runs again on every invalidation, and params still in the URL would be re-applied over whatever the user had changed since. It also means the URL the user can copy is a plain card-creator URL rather than someone else's link. The card itself does not survive a reload either way — the store is in memory until the user saves.
- **Apply what is valid, notice what was ignored.** Silent dropping leaves the external developer debugging blind; hard-failing punishes the end user for a third party's typo.
- **A blank value is not a value.** Every param is trimmed, and an empty result is reported rather than written, since a param that can't change anything visible is a link author's mistake.
- **Values that aren't textual are reported.** The router parses search values before the loader sees them, so a JSON-looking value arrives as an object. Nothing in this vocabulary needs one, and coercing would write `[object Object]` onto a card.
- **Text is plain text only.** `CardTextHTML` feeds `dangerouslySetInnerHTML`; keeping it editor-produced means that surface never opens.
- **Artwork by remote URL**, fetched to a Blob. Any `https` host, no allowlist, size ceiling enforced.
- **Frames are addressable by name**, resolved within the chosen type and style. Stock frames only.
- **Hybrid is addressable.** The right-hand frame param is what makes a card hybrid, inheriting the store invariant that there is no separate flag, so "hybrid on with no right frame" stays unrepresentable in a link too.
- **No meld.** It is the one shape with genuinely nested state and would force a nesting convention on a flat vocabulary before anyone has asked for it.

## Param vocabulary

Single source of truth: `url-params/vocabulary.ts`. Free text means the field accepts any string.

| Param | Store key | Accepted values |
|---|---|---|
| `type` | `CardType` | keys of `CardTypes` except `meld` |
| `style` | `CardBackStyle` | `dented`, `flat` |
| `frame` | `CardBack` | stock frame name, case-insensitive |
| `frame2` | `CardBackRight` | stock frame name, case-insensitive; presence makes the card hybrid |
| `split` | `CardBackSplit` | integer 2 to 98, percent across the card |
| `blend` | `CardBackBlend` | integer 0 to 100, percent of maximum seam softness |
| `name` | `CardName` | free text |
| `pitch` | `CardPitch` | `1`, `2`, `3` |
| `cost` | `CardResource` | free text (the UI labels this Cost) |
| `power` | `CardPower` | free text |
| `defense` | `CardDefense` | free text |
| `life` | `CardLife` | free text |
| `intellect` | `CardHeroIntellect` | free text |
| `class` | `CardClass` | keys of `CardClasses` |
| `class2` | `CardSecondaryClass` | keys of `CardClasses` |
| `talent` | `CardTalent` | keys of `CardTalents` |
| `subtype` | `CardSubType` | free text |
| `rarity` | `CardRarity` | keys of `CardRarities` |
| `weapon` | `CardWeapon` | `1h`, `2h` |
| `group` | `CardMacroGroup` | free text |
| `text` | `CardTextNode` + `CardTextHTML` | plain text, newlines, `:shortcode:` |
| `artist` | `CardArtworkCredits` | free text |
| `setnumber` | `CardSetNumber` | free text, uppercased by the parser |
| `art` | `CardArtwork` | `https` URL |

`CardResource` is the pitch *cost*; `CardPitch` is the pitch *colour*. The public names must not repeat that confusion.

## Frames and hybrid

- **Resolution.** `frame` and `frame2` are matched case-insensitively against the `name` of the frames `getCardBacksForTypeAndStyle` returns for the chosen type and style. Frame names are not unique across the manifest (Aria exists as both `general` and `hero`), so type and style are what make a name resolve to one frame.
- **Custom frames never match.** Reading the manifest directly, rather than filtering `source === "custom"` out of `getAvailableCardBacks`, makes that structural: there is no filter for a later edit to drop. A public link resolving against a custom frame would pick up whatever the recipient happens to have uploaded under that name, and their ids are local IndexedDB rows that mean nothing on another device.
- **Unresolvable name** is ignored with a notice, and the frame falls back to the suggested one for the type and style. This covers the four type and style combinations `getCardBacksForTypeAndStyle` returns an empty list for.
- **`frame2` alone is valid.** The left frame falls back to the suggested one and the card is still hybrid.
- **`split` or `blend` without `frame2`** cannot affect anything rendered, so they are ignored with a notice rather than stored as invisible state.
- **Percent, not fraction.** The store holds `CardBackSplit` and `CardBackBlend` as 0..1, but a link author writing `split=0.5` versus `split=50` will guess wrong, so the public unit is a percentage and the parser divides. `split`'s bounds are the store's own `HYBRID_SPLIT_MIN` and `HYBRID_SPLIT_MAX` expressed as percentages.
- **Out of range is ignored with a notice** and falls back to the default, matching how `pitch=7` is treated. Do not silently clamp.
- **No centre snapping.** `setCardBackSplit` magnetises to dead centre within `HYBRID_SPLIT_SNAP`, which exists to make dragging land on 50. A link author writing `split=49` means 49, so the parser must not replicate it. This is exactly the kind of action side effect the patch-ordering section is about.

## Modules

New folder `src/apps/card-creator/url-params/`:

| File | Contents |
|---|---|
| `vocabulary.ts` | param name to store key, plus a value parser per param, and the ignore reasons |
| `parse.ts` | the router's search record to `{ patch, textDoc, artworkUrl, ignored }`, pure |
| `text.ts` | plain text to a Tiptap document, and that document to HTML |
| `artwork.ts` | `getArtworkUrl(value)` and `getArtworkBlob(url, signal)` |
| `notice.ts` | the ignored-param list, survives the strip navigation |
| `index.ts` | `applyPrefillParams`, called by the route loader |

The banner that shows the notice is a component under `components/card-creator/`, like every other piece of card-creator UI; only its state lives in `url-params/`.

`parse.ts` reads nothing outside its arguments and the frame manifest, so the whole vocabulary is testable with no browser. The two steps that need one — serialising the text to HTML, and fetching the artwork — are in `index.ts`, on the other side of that line.

Not in `shared/`: this vocabulary is card-creator's public interface, not FAB domain data.

## Applying the patch

The order matters and is the least obvious part of the work.

- `loadCard(patch)` resets to initial state and merges, so it must run **once**, with a complete patch, before anything else.
- `loadCard` is a raw merge and runs **no** side effects, so `parse.ts` has to do for itself what `setCardType` would normally do:
  - resolve `CardBack` and `CardBackRight` for the chosen type and style via `getAvailableCardBacks` plus `getSuggestedCardBack`, since the initial-state default is the action/dented frame and would otherwise stick to a `type=hero` link;
  - leave `CardBackRight` null unless `frame2` resolved, since that null is what encodes "not hybrid";
  - drop params for fields that `isFieldVisible` says the chosen type does not show, adding each to `ignored`;
  - uppercase `setnumber`, which `setCardSetNumber` would have done.
- `CardTextHTML` is generated in `index.ts` and merged into the same `loadCard` call. `generateHTML` serialises through the global `document`, so it cannot live in `parse.ts` without dragging a DOM into the tests; both text fields still reach the store together, which is the invariant that matters.
- Artwork goes through `setCardArtwork(blob)` **after** `loadCard`, because it is async and seeds `CardArtPosition` from the image's natural dimensions.

## Route wiring

- `validateSearch` on `/card-creator` returns the raw record without throwing; `loaderDeps` passes it to the loader.
- The loader applies the patch, awaits the artwork fetch (bounded by the loader's own `abortController`), records the ignored list in `notice.ts`, then `throw redirect({ to: "/card-creator", search: {}, replace: true })`.
- The redirect re-runs the loader against an empty search, which applies nothing. The notice lives in `notice.ts` rather than loader data precisely because loader data does not survive that second pass.
- `reset-form.tsx` is the existing precedent for throwing a redirect from a loader.

Applying in the loader rather than an effect means the card is complete on first paint, with no flash of an empty form.

## Text conversion

- Accepted: literal text, newlines as paragraph breaks, `:cost:` style shortcodes.
- `extensions/Emoji.ts` already treats `:name:` as the canonical text form (input rule, paste rule, and `renderText`), so the shortcode vocabulary is the one users already type: `cost`, `power`, `defense`, `life`, `intellect`, `tap`, `untap`, `chi`.
- Unknown shortcodes stay as literal text, exactly as the editor leaves them.
- The param value is never parsed as markup. `<b>` and `<script>` arrive as visible characters.
- Both `CardTextNode` and `CardTextHTML` must be set. `RichTextEditor`'s `onUpdate` fires only on user edits, so setting the node alone leaves the renderer blank until the first keystroke.
- To keep the generated HTML identical to the editor's own output, extract the extension array out of `RichTextEditor`'s inline `useEditor` call into a `getRichTextExtensions(customEmojis)` export beside `extensions/`, and generate from that via `generateHTML(doc, extensions)` from `@tiptap/core`. No new dependency, and no hand-built HTML to keep in step with `Emoji.renderHTML`.

## Artwork fetch

- `https` only. `http` is blocked as mixed content before the request starts anyway.
- Plain `fetch`, then `res.blob()`, then `setCardArtwork`. The renderer reads it back through `useObjectURL`, so the DOM only ever sees a same-origin `blob:` URL and snapdom never touches a cross-origin image. No tainted canvas, no export breakage.
- The host must send `Access-Control-Allow-Origin`. `mode: "no-cors"` is not a workaround: the opaque response's blob is unusable. Per-host support has to be checked empirically.
- Size ceiling in the low tens of MB, enforced by reading `Content-Length` and aborting past it.
- Any failure (CORS, 404, timeout, oversize) goes to the notice. The card still opens with everything else applied.
- Once the user saves, the Blob is persisted to IndexedDB, so the card survives the source host going away.
- `CardOverlay` is not addressable: it is behind `import.meta.env.DEV` in the route, so exposing it would surface a dev-only field through a public API.

Accepted, in exchange for the feature being useful at all:

- Opening a link makes the recipient's browser hit an attacker-chosen host, disclosing IP and user agent. No cookies are sent, since `fetch` omits credentials cross-origin by default.
- A hand-crafted link can render arbitrary imagery inside a page that looks like FABKIT, which matters because these links get pasted into Discord.

An allowlist does not address either of those (both work just as well from an allowlisted image host), so it would cost reach and maintenance for no security gain.

## Notice UI

- Inline dismissible banner at the top of the card-creator route, local to the app.
- The platform layer has no toast system (`platform/components/` has `DevBanner`, `Tooltip`, `AppErrorFallback`). Building one is a platform decision that deserves its own driver, not this feature.
- All copy through `t()` in the `card-creator` namespace.
- Content: which params were ignored and why, in one line each.

## Tests

`tests/prefill-links.test.ts`, alongside `backwards-compatibility.test.ts`. The repo has no colocated tests.

Frame resolution is pinned against the store itself: for every addressable type and style, the parser must land on the same frame and style `setCardType` does. That is the invariant the whole frame section exists to satisfy, and it survives frames being added to the manifest.

HTML generation needs a DOM and is out of the pure tests, like the artwork fetch. Both are verified by opening a link in the running app.

- Each param maps to its store key with a representative value.
- Unknown param name lands in `ignored`.
- Invalid enum value (`class=ninjas`, `pitch=7`) lands in `ignored`, and the rest of the link still applies.
- A param for a field the chosen type does not show lands in `ignored`.
- `type=meld` is rejected, falls back to the default type, and produces a notice.
- Absent `type` falls back to the default.
- `CardBack` resolves correctly for each type and style combination, including the four combinations `getCardBacksForTypeAndStyle` returns empty for.
- `frame` resolves case-insensitively, and a name that exists under a different type (Aria as `hero` when the link says `type=action`) resolves to the right one.
- A `frame` name that matches only a custom frame does not resolve, and lands in `ignored`.
- `frame2` sets `CardBackRight`; its absence leaves `CardBackRight` null.
- `split=25` becomes `0.25`; `split=49` stays `0.49` and is not snapped to centre.
- `split=150` and `blend=-1` land in `ignored` and leave the defaults in place.
- `split` or `blend` without `frame2` lands in `ignored`.
- Text: newlines become paragraphs, `:cost:` becomes an emoji node, an unknown shortcode stays literal, and `<script>alert(1)</script>` round-trips as visible text.
- Artwork URL validation rejects non-`https`. The fetch itself needs a browser and stays out of the pure tests.

## Docs

- `docs/prefill-links.md`, a new folder. Written for an external developer: the vocabulary table, the hash-position gotcha, the CORS requirement for `art`, the shortcode list, and the append-only promise. It does not list the stock frame names — they are generated data that would go stale, so it points at the frame picker, which always shows the names for a given type and style.
- The vocabulary table lives in exactly one place. Anything else that needs it links to that heading.

## Out of scope

- Meld params.
- Custom frames as `frame` or `frame2` values.
- `CardOverlay`.
- An opaque encoded-state param.
- Two-way binding of the URL to the form.
- An in-app documentation page.

## Known cost

`frame` and `frame2` are the only params whose vocabulary is data rather than code: their accepted values come from the names in `cardbacks.json`, which is auto-generated. Renaming a stock frame there breaks any published link that used the old name. The alternative, addressing frames by numeric `id`, is worse: the ids are positional in a generated file and carry no meaning for a link author.
